### PR TITLE
Prime helix

### DIFF
--- a/examples/helix_demo.py
+++ b/examples/helix_demo.py
@@ -1,0 +1,57 @@
+# examples/helix_demo.py
+"""
+Prime-helix visual sanity-check.
+
+Run with:
+    python examples/helix_demo.py
+"""
+
+import math
+import networkx as nx
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D                         # noqa: F401
+
+
+from tetrakis_sim.prime_helix import add_prime_helix
+
+# ---------------------------------------------------------------------------
+# Parameters you may want to tweak quickly
+# ---------------------------------------------------------------------------
+N_RINGS  = 12                    # how many prime rings to draw
+DTHETA   = math.radians(8)       # rotation increment (° → rad)
+PITCH    = 2.0                   # vertical step between rings
+NODE_SZ  = 18                    # marker size in points
+C_MAP = plt.get_cmap("viridis", N_RINGS)    # discrete colours per ring
+# ---------------------------------------------------------------------------
+
+
+def plot_3d_graph_with_edges(G: nx.Graph) -> None:
+    """Scatter + thin edges for every ring to reveal diamond outlines."""
+    fig = plt.figure(figsize=(7, 6))
+    ax = fig.add_subplot(111, projection="3d")
+
+    # iterate rings so colour can be assigned per ring
+    for k in range(N_RINGS):
+        verts = [G.nodes[(k, j)]["pos"] for j in range(5)]       # 5 vertices
+        xs, ys, zs = zip(*verts)
+
+        # scatter vertices
+        ax.scatter(xs, ys, zs, s=NODE_SZ, color=C_MAP(k), depthshade=True)
+
+        # draw outline
+        ax.plot(xs, ys, zs, linewidth=0.6, color=C_MAP(k), alpha=0.7)
+
+    ax.set_title("Prime-helix demo")
+    ax.set_xlabel("x"); ax.set_ylabel("y"); ax.set_zlabel("z")
+    plt.tight_layout()
+    plt.show()
+
+
+def main() -> None:
+    G = nx.Graph()
+    add_prime_helix(G, n_rings=N_RINGS, dtheta=DTHETA, pitch=PITCH)
+    plot_3d_graph_with_edges(G)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/helix_demo.py
+++ b/examples/helix_demo.py
@@ -36,13 +36,17 @@ def plot_3d_graph_with_edges(G: nx.Graph) -> None:
         xs, ys, zs = zip(*verts)
 
         # scatter vertices
-        ax.scatter(xs, ys, zs, s=NODE_SZ, color=C_MAP(k), depthshade=True)
+        ax.scatter(xs, ys, zs, s=NODE_SZ, color=C_MAP(k), depthshade=True, picker=True, label=f"ring {k}",  )
 
         # draw outline
-        ax.plot(xs, ys, zs, linewidth=0.6, color=C_MAP(k), alpha=0.7)
+        ax.plot(xs, ys, zs, linewidth=0.6, color=C_MAP(k), alpha=0.7, antialiased=True, )
 
     ax.set_title("Prime-helix demo")
     ax.set_xlabel("x"); ax.set_ylabel("y"); ax.set_zlabel("z")
+    plt.tight_layout()
+    plt.show()
+
+    plt.savefig("prime_helix_demo.png", dpi=180, bbox_inches="tight")
     plt.tight_layout()
     plt.show()
 

--- a/examples/helix_demo.py
+++ b/examples/helix_demo.py
@@ -46,7 +46,7 @@ def plot_3d_graph_with_edges(G: nx.Graph) -> None:
     plt.tight_layout()
     plt.show()
 
-    plt.savefig("prime_helix_demo.png", dpi=180, bbox_inches="tight")
+    fig.savefig("prime_helix_demo.png", dpi=180, bbox_inches="tight")
     plt.tight_layout()
     plt.show()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # For local dev and notebooks ONLY:
 jupyter==1.0.0
 ipywidgets==8.1.2
+pandas

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,9 @@
+def test_plot_floor_runs_without_error():
+    from tetrakis_sim.lattice import build_sheet
+    from tetrakis_sim.defects import apply_blackhole_defect, find_event_horizon
+    from tetrakis_sim.plot import plot_floor_with_circle
+
+    G = build_sheet(size=5, dim=3, layers=2)
+    removed = apply_blackhole_defect(G, (2,2,1), 1.5)
+    horizon = find_event_horizon(G, removed, 1.5, (2,2,1))
+    plot_floor_with_circle(G, 1, (2,2,1), 1.5, highlight_nodes=removed, boundary_nodes=horizon, show=False)

--- a/tests/test_prime_helix.py
+++ b/tests/test_prime_helix.py
@@ -1,0 +1,15 @@
+import networkx as nx
+from tetrakis_sim.prime_helix import add_prime_helix
+
+def test_ring_and_node_counts():
+    G = nx.Graph()
+    add_prime_helix(G, n_rings=6)
+    assert {d["ring"] for _, d in G.nodes(data=True)} == set(range(6))
+    # each diamond has 5 vertices
+    assert len(G) == 6 * 5
+
+def test_positions_have_three_coords():
+    G = nx.Graph()
+    add_prime_helix(G, n_rings=1)
+    n, d = next(iter(G.nodes(data=True))) 
+    assert len(d["pos"]) == 3

--- a/tetrakis_sim/__init__.py
+++ b/tetrakis_sim/__init__.py
@@ -1,0 +1,17 @@
+"""
+tetrakis_sim
+============
+
+Core simulation and visualisation utilities for the Tetrakis-Sim project.
+"""
+
+# ---------------------------------------------------------------------------
+# Public re-exports
+# ---------------------------------------------------------------------------
+from .prime_helix import add_prime_helix          # geometry builder
+from .plot import plot_3d_graph                   # lightweight 3-D scatter
+
+__all__: list[str] = [
+    "add_prime_helix",
+    "plot_3d_graph",
+]


### PR DESCRIPTION
## ✨  Summary
Adds the **Prime-Helix geometry feature** and a self-contained 3-D demo.

* **`tetrakis_sim/prime_helix.py`** – new builder `add_prime_helix`
* **`tetrakis_sim/plot.py`**        – new helper `plot_3d_graph`
* **`examples/helix_demo.py`**      – interactive Matplotlib demo + auto-PNG
* **Tests** – `tests/test_prime_helix.py` (updated) and existing smoke-tests
* **Docs** – demo screenshot `prime_helix_demo.png`

---

## 📚  Motivation
This completes the **Geometry Milestone** on our roadmap.  
It gives us a visual, testable scaffold for prime-ring experiments before we
wrap them onto an abelian-surface period lattice (next milestone).

---

## ✅  What changed

| Category | File(s) | Details |
|----------|---------|---------|
| **Feature** | `tetrakis_sim/prime_helix.py` | Generates rotated L¹ diamonds whose radii are primes; constant vertical pitch. |
| **Feature** | `tetrakis_sim/plot.py` | Adds `plot_3d_graph(G, …)` – minimalist 3-D scatter for any graph with `pos=(x,y,z)`. |
| **Demo** | `examples/helix_demo.py` | Colours rings, draws outlines, saves *prime_helix_demo.png*. |
| **Test** | `tests/test_prime_helix.py` | Ensures correct ring count and 3-coordinate positions. |
| **API**  | `tetrakis_sim/__init__.py` | Re-exports `add_prime_helix` and `plot_3d_graph`. |

---

## 🔬  How to try it

```bash
# fresh venv
pip install -r requirements.txt -r requirements-dev.txt
pytest -q                     # all tests should pass
python examples/helix_demo.py # shows window and writes prime_helix_demo.png



