### PR TITLE
Prime helix

### DIFF
--- a/examples/helix_demo.py
+++ b/examples/helix_demo.py
@@ -1,0 +1,57 @@
+# examples/helix_demo.py
+"""
+Prime-helix visual sanity-check.
+
+Run with:
+    python examples/helix_demo.py
+"""
+
+import math
+import networkx as nx
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D                         # noqa: F401
+
+
+from tetrakis_sim.prime_helix import add_prime_helix
+
+# ---------------------------------------------------------------------------
+# Parameters you may want to tweak quickly
+# ---------------------------------------------------------------------------
+N_RINGS  = 12                    # how many prime rings to draw
+DTHETA   = math.radians(8)       # rotation increment (° → rad)
+PITCH    = 2.0                   # vertical step between rings
+NODE_SZ  = 18                    # marker size in points
+C_MAP = plt.get_cmap("viridis", N_RINGS)    # discrete colours per ring
+# ---------------------------------------------------------------------------
+
+
+def plot_3d_graph_with_edges(G: nx.Graph) -> None:
+    """Scatter + thin edges for every ring to reveal diamond outlines."""
+    fig = plt.figure(figsize=(7, 6))
+    ax = fig.add_subplot(111, projection="3d")
+
+    # iterate rings so colour can be assigned per ring
+    for k in range(N_RINGS):
+        verts = [G.nodes[(k, j)]["pos"] for j in range(5)]       # 5 vertices
+        xs, ys, zs = zip(*verts)
+
+        # scatter vertices
+        ax.scatter(xs, ys, zs, s=NODE_SZ, color=C_MAP(k), depthshade=True)
+
+        # draw outline
+        ax.plot(xs, ys, zs, linewidth=0.6, color=C_MAP(k), alpha=0.7)
+
+    ax.set_title("Prime-helix demo")
+    ax.set_xlabel("x"); ax.set_ylabel("y"); ax.set_zlabel("z")
+    plt.tight_layout()
+    plt.show()
+
+
+def main() -> None:
+    G = nx.Graph()
+    add_prime_helix(G, n_rings=N_RINGS, dtheta=DTHETA, pitch=PITCH)
+    plot_3d_graph_with_edges(G)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/helix_demo.py
+++ b/examples/helix_demo.py
@@ -36,13 +36,17 @@ def plot_3d_graph_with_edges(G: nx.Graph) -> None:
         xs, ys, zs = zip(*verts)
 
         # scatter vertices
-        ax.scatter(xs, ys, zs, s=NODE_SZ, color=C_MAP(k), depthshade=True)
+        ax.scatter(xs, ys, zs, s=NODE_SZ, color=C_MAP(k), depthshade=True, picker=True, label=f"ring {k}",  )
 
         # draw outline
-        ax.plot(xs, ys, zs, linewidth=0.6, color=C_MAP(k), alpha=0.7)
+        ax.plot(xs, ys, zs, linewidth=0.6, color=C_MAP(k), alpha=0.7, antialiased=True, )
 
     ax.set_title("Prime-helix demo")
     ax.set_xlabel("x"); ax.set_ylabel("y"); ax.set_zlabel("z")
+    plt.tight_layout()
+    plt.show()
+
+    plt.savefig("prime_helix_demo.png", dpi=180, bbox_inches="tight")
     plt.tight_layout()
     plt.show()
 

--- a/examples/helix_demo.py
+++ b/examples/helix_demo.py
@@ -46,7 +46,7 @@ def plot_3d_graph_with_edges(G: nx.Graph) -> None:
     plt.tight_layout()
     plt.show()
 
-    plt.savefig("prime_helix_demo.png", dpi=180, bbox_inches="tight")
+    fig.savefig("prime_helix_demo.png", dpi=180, bbox_inches="tight")
     plt.tight_layout()
     plt.show()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # For local dev and notebooks ONLY:
 jupyter==1.0.0
 ipywidgets==8.1.2
+pandas

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,9 @@
+def test_plot_floor_runs_without_error():
+    from tetrakis_sim.lattice import build_sheet
+    from tetrakis_sim.defects import apply_blackhole_defect, find_event_horizon
+    from tetrakis_sim.plot import plot_floor_with_circle
+
+    G = build_sheet(size=5, dim=3, layers=2)
+    removed = apply_blackhole_defect(G, (2,2,1), 1.5)
+    horizon = find_event_horizon(G, removed, 1.5, (2,2,1))
+    plot_floor_with_circle(G, 1, (2,2,1), 1.5, highlight_nodes=removed, boundary_nodes=horizon, show=False)

--- a/tests/test_prime_helix.py
+++ b/tests/test_prime_helix.py
@@ -1,0 +1,15 @@
+import networkx as nx
+from tetrakis_sim.prime_helix import add_prime_helix
+
+def test_ring_and_node_counts():
+    G = nx.Graph()
+    add_prime_helix(G, n_rings=6)
+    assert {d["ring"] for _, d in G.nodes(data=True)} == set(range(6))
+    # each diamond has 5 vertices
+    assert len(G) == 6 * 5
+
+def test_positions_have_three_coords():
+    G = nx.Graph()
+    add_prime_helix(G, n_rings=1)
+    n, d = next(iter(G.nodes(data=True))) 
+    assert len(d["pos"]) == 3

--- a/tetrakis_sim/__init__.py
+++ b/tetrakis_sim/__init__.py
@@ -1,0 +1,17 @@
+"""
+tetrakis_sim
+============
+
+Core simulation and visualisation utilities for the Tetrakis-Sim project.
+"""
+
+# ---------------------------------------------------------------------------
+# Public re-exports
+# ---------------------------------------------------------------------------
+from .prime_helix import add_prime_helix          # geometry builder
+from .plot import plot_3d_graph                   # lightweight 3-D scatter
+
+__all__: list[str] = [
+    "add_prime_helix",
+    "plot_3d_graph",
+]

--- a/tetrakis_sim/plot.py
+++ b/tetrakis_sim/plot.py
@@ -222,3 +222,34 @@ def plot_lattice_3d(
         fig.write_html(filename_html)
     if filename_img:
         fig.write_image(filename_img)
+
+
+# ---------------------------------------------------------------------------
+# Generic 3-D scatter for any graph that stores Cartesian positions
+# ---------------------------------------------------------------------------
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D      # noqa: F401 – registers 3-D proj
+
+def plot_3d_graph(G, node_size: int = 10, title: str = "3-D graph") -> None:
+    """
+    Scatter-plot any NetworkX graph whose nodes carry
+    ``'pos' = (x, y, z)`` coordinates.
+
+    Parameters
+    ----------
+    G : networkx.Graph
+        Graph with a ``pos`` attribute on every node.
+    node_size : int, optional
+        Marker size, by default 10.
+    title : str, optional
+        Plot title.
+    """
+    xs, ys, zs = zip(*(G.nodes[n]["pos"] for n in G))
+    fig = plt.figure(figsize=(6, 5))
+    ax = fig.add_subplot(111, projection="3d")
+    ax.scatter(xs, ys, zs, s=node_size)
+    ax.set_title(title)
+    ax.set_xlabel("x"); ax.set_ylabel("y"); ax.set_zlabel("z")
+    plt.show()
+

--- a/tetrakis_sim/prime_helix.py
+++ b/tetrakis_sim/prime_helix.py
@@ -1,0 +1,90 @@
+# tetrakis_sim/prime_helix.py
+"""
+Prime-ring helix
+================
+Builds a helical stack of L¹-norm “diamond” rings whose radii are the prime
+numbers 2, 3, 5, 7, 11, …  Each ring is rotated by a fixed increment and
+lifted by a constant pitch, giving a 3-D spiral that climbs to infinity.
+
+Public API
+----------
+add_prime_helix(G, n_rings=100, dtheta=math.radians(1), pitch=1.5)
+"""
+
+from __future__ import annotations
+import math
+from typing import List, Tuple
+
+import numpy as np
+import networkx as nx
+from sympy import primerange
+
+__all__ = ["add_prime_helix"]
+
+
+# ---------------------------------------------------------------------------
+# Low-level geometry helpers
+# ---------------------------------------------------------------------------
+
+def _diamond_L1(radius: float) -> np.ndarray:
+    """Return 5×2 array of vertices for ‖(x,y)‖₁ = radius (closed path)."""
+    return np.array([
+        ( radius, 0),
+        ( 0,  radius),
+        (-radius, 0),
+        ( 0, -radius),
+        ( radius, 0),
+    ], dtype=float)
+
+
+def _rotated_lifted(radius: float, theta: float, z: float) -> np.ndarray:
+    """
+    Rotate the diamond in-plane by *theta* and append height *z*.
+
+    Returns
+    -------
+    verts : ndarray, shape (5, 3)
+        Ordered vertices (x,y,z) tracing the diamond.
+    """
+    c, s = math.cos(theta), math.sin(theta)
+    R = np.array([[c, -s],
+                  [s,  c]])
+    xy = (R @ _diamond_L1(radius).T).T        # (5,2)
+    zcol = np.full((xy.shape[0], 1), z)
+    return np.hstack([xy, zcol])
+
+
+# ---------------------------------------------------------------------------
+# Public builder
+# ---------------------------------------------------------------------------
+
+def add_prime_helix(
+    G: nx.Graph,
+    n_rings: int = 100,
+    dtheta: float = math.radians(1),
+    pitch: float = 1.5,
+) -> None:
+    """
+    Append `n_rings` rotated prime diamonds to graph *G*.
+
+    Each node receives attributes:
+    -------------------------------
+    pos  : tuple[float, float, float]   3-D coordinates
+    ring : int                          ring index (0 = p₂)
+    prime_radius : int                  prime radius (2, 3, 5, …)
+    """
+    primes = list(primerange(2, 10**8))[:n_rings]
+
+    for k, p in enumerate(primes):
+        verts = _rotated_lifted(p, k * dtheta, k * pitch)
+
+        prev_id = None
+        for j, (x, y, z) in enumerate(verts):
+            node_id = (k, j)                   # unique & hashable
+            G.add_node(node_id,
+                       pos=(float(x), float(y), float(z)),
+                       ring=k,
+                       prime_radius=p)
+            if prev_id is not None:
+                G.add_edge(prev_id, node_id, ring=k)
+            prev_id = node_id


### PR DESCRIPTION
## ✨  Summary
Add the **Prime-Helix geometry module** plus a reusable 3-D plotting helper and a runnable demo.

* **`tetrakis_sim/prime_helix.py`** – new builder `add_prime_helix`
* **`tetrakis_sim/plot.py`**        – new helper `plot_3d_graph`
* **`examples/helix_demo.py`**      – interactive Matplotlib demo, outlines + colour ramp
* **Tests**                         – `test_prime_helix.py` (ring & pos checks)
* **Screenshot**                    – `prime_helix_demo.png`

---

## 📚  Motivation
This closes the **Geometry Milestone**: we now have a visual, testable scaffold mapping prime rings before we lift them onto an abelian-surface lattice (next milestone).

---

## ✅  What changed

| Category  | File(s) | Details |
|-----------|---------|---------|
| **Feature** | `tetrakis_sim/prime_helix.py` | Generates rotated L¹-diamonds at prime radii with constant pitch. |
| **Feature** | `tetrakis_sim/plot.py`        | Adds `plot_3d_graph(G, …)` – lightweight scatter for any graph with `pos=(x,y,z)`. |
| **Demo**  | `examples/helix_demo.py`        | Colours each ring, draws outlines, auto-exports `prime_helix_demo.png`. |
| **Tests** | `tests/test_prime_helix.py`      | Verifies ring count & 3-coord positions (fixed unpack). |
| **API**   | `tetrakis_sim/__init__.py`       | Re-exports `add_prime_helix`, `plot_3d_graph`. |

---

## 🔬  How to test

```bash
# fresh venv (Python ≥3.9)
pip install -r requirements.txt -r requirements-dev.txt
pytest -q                     # all tests should pass
python examples/helix_demo.py # interactive window + PNG export
