### PR TITLE
Finish physics helpers and stabilise batch CLI

### DIFF
--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,0 +1,56 @@
+import math
+import networkx as nx
+import numpy as np
+import pytest
+
+from tetrakis_sim.defects import apply_wedge_defect
+from tetrakis_sim.lattice import build_sheet
+from tetrakis_sim.physics import (
+    SimulationHistory,
+    apply_defect as physics_apply_defect,
+    run_fft,
+    run_wave_sim,
+)
+
+
+def test_run_wave_sim_attaches_metadata():
+    G = nx.path_graph(3)
+    with pytest.warns(RuntimeWarning):
+        history = run_wave_sim(G, steps=3, c=1.0, dt=5.0)
+
+    assert isinstance(history, SimulationHistory)
+    assert history.dt == pytest.approx(1 / math.sqrt(2))
+    assert history.metadata["stability_adjusted"] is True
+    assert history.metadata["max_degree"] == 2
+
+
+def test_run_fft_uses_history_dt():
+    states = [{0: 0.0}, {0: 1.0}, {0: 0.0}, {0: -1.0}]
+    history = SimulationHistory(states, dt=0.5, wave_speed=1.0)
+
+    freq, spectrum, values = run_fft(history, node=0)
+
+    assert np.allclose(values, [0.0, 1.0, 0.0, -1.0])
+    assert pytest.approx(freq[1]) == 0.5  # second bin corresponds to 1 / (N*dt)
+    assert np.argmax(spectrum) in (1, 3)
+
+
+def test_apply_wedge_defect_supports_3d():
+    G = build_sheet(size=3, dim=3, layers=2)
+    center = (1, 1, 0)
+    apply_wedge_defect(G, center=center[:2], layer=center[2])
+
+    assert not G.has_edge((1, 1, 0, "A"), (1, 1, 0, "B"))
+    assert G.has_edge((1, 1, 1, "A"), (1, 1, 1, "B"))
+
+
+def test_physics_apply_defect_returns_removed_nodes():
+    G = build_sheet(size=5, dim=3, layers=3)
+    center = (2, 2, 1)
+    _, removed = physics_apply_defect(
+        G, defect_type="blackhole", center=center, radius=1.5
+    )
+
+    assert removed
+    for node in removed:
+        assert math.dist(node[:3], center) < 1.5

--- a/tetrakis_sim/defects.py
+++ b/tetrakis_sim/defects.py
@@ -1,36 +1,136 @@
 # tetrakis_sim/defects.py
 
-import math
-import networkx as nx
-from typing import Tuple, List, Optional
+from __future__ import annotations
 
-def apply_wedge_defect(G: nx.Graph, center: Optional[Tuple[int, int]] = None) -> nx.Graph:
+import math
+import warnings
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import networkx as nx
+
+
+@dataclass(frozen=True)
+class DefectResult:
+    """Container describing the side-effects of a defect application.
+
+    Attributes
+    ----------
+    graph:
+        The mutated graph (identical object passed into the defect helper).
+    removed_nodes:
+        Sequence of nodes removed from the graph.  Only populated for defects
+        that physically delete nodes (e.g., the black-hole defect).
+    removed_edges:
+        Sequence of edges removed from the graph.  Used for defects such as the
+        wedge deficit which only excises edges.
+    metadata:
+        Free-form dictionary for future extensions.
     """
-    Apply a +45° wedge deficit at the grid center.
-    Removes edge between center 'A' and 'B' nodes (2D only).
+
+    graph: nx.Graph
+    removed_nodes: Tuple = ()
+    removed_edges: Tuple = ()
+    metadata: Optional[dict] = None
+
+    def __post_init__(self) -> None:
+        if self.metadata is None:
+            object.__setattr__(self, "metadata", {})
+
+    def __iter__(self):  # pragma: no cover - convenience for unpacking
+        yield self.graph
+        yield list(self.removed_nodes)
+
+def _infer_center_coordinates(G: nx.Graph) -> Tuple[int, int]:
+    rows = sorted({node[0] for node in G.nodes})
+    cols = sorted({node[1] for node in G.nodes})
+    return rows[len(rows) // 2], cols[len(cols) // 2]
+
+
+def _infer_layers(G: nx.Graph) -> List[int]:
+    return sorted({node[2] for node in G.nodes if len(node) > 3})
+
+
+def apply_wedge_defect(
+    G: nx.Graph,
+    center: Optional[Tuple[int, int]] = None,
+    layer: Optional[int] = None,
+    *,
+    return_result: bool = False,
+) -> nx.Graph | DefectResult:
+    """Apply a +45° wedge deficit around the grid centre.
+
+    The classic wedge defect removes the edge between the "A" and "B" vertices
+    of the central cell.  Historically the implementation only worked for 2-D
+    lattices (triplets).  This helper now supports both 2-D and 3-D lattices:
+
+    * 2-D: remove the single (A,B) edge at the requested ``center``.
+    * 3-D: remove the (A,B) edge on the specified ``layer``.  If no layer is
+      supplied the central layer is used.  All other layers are left intact.
     """
+
+    if not G.nodes:
+        return DefectResult(G)
+
+    node_length = len(next(iter(G.nodes)))
+    if node_length not in (3, 4):
+        raise ValueError("Unsupported node format for wedge defect")
+
     if center is None:
-        # Infer center from node labels (works for 2D)
-        rows = [r for r, _, _ in G.nodes]
-        cols = [c for _, c, _ in G.nodes]
-        center = (rows[len(rows)//2], cols[len(cols)//2])
-    try:
-        G.remove_edge((center[0], center[1], "A"), (center[0], center[1], "B"))
-    except Exception:
-        print(f"No edge found at {center} to remove.")
-    return G
+        center = _infer_center_coordinates(G)
+
+    removed_edges: List[Tuple] = []
+
+    if node_length == 3:
+        edge = ((center[0], center[1], "A"), (center[0], center[1], "B"))
+        if G.has_edge(*edge):
+            G.remove_edge(*edge)
+            removed_edges.append(edge)
+        else:  # pragma: no cover - defensive fallback
+            warnings.warn(f"No wedge edge found at {center} to remove.")
+        result = DefectResult(G, removed_edges=tuple(removed_edges))
+        return result if return_result else result.graph
+
+    # 3-D lattice handling
+    layers = _infer_layers(G)
+    if not layers:
+        raise ValueError("Expected z-layer component for 3-D wedge defect")
+
+    if layer is None:
+        layer = layers[len(layers) // 2]
+
+    if layer not in layers:
+        raise ValueError(f"Layer {layer} is outside of lattice range {layers}")
+
+    edge = (
+        (center[0], center[1], layer, "A"),
+        (center[0], center[1], layer, "B"),
+    )
+    if G.has_edge(*edge):
+        G.remove_edge(*edge)
+        removed_edges.append(edge)
+    else:  # pragma: no cover - defensive fallback
+        warnings.warn(
+            f"No wedge edge found at {center} on layer {layer} to remove."
+        )
+    result = DefectResult(G, removed_edges=tuple(removed_edges))
+    return result if return_result else result.graph
 
 def apply_blackhole_defect(
     G: nx.Graph,
     center: Tuple[int, ...],
-    radius: float
-) -> List:
+    radius: float,
+    *,
+    return_result: bool = False,
+) -> List | DefectResult:
+    """Remove all nodes within ``radius`` of ``center``.
+
+    The return value retains the previous behaviour of returning the list of
+    removed nodes while also bundling the mutated graph and providing a uniform
+    :class:`DefectResult` container that other defects now use as well.
     """
-    Removes all nodes (and their edges) within a given radius of center.
-    Returns the list of removed nodes.
-    Works for both 2D and 3D lattices.
-    """
-    nodes_to_remove = []
+
+    nodes_to_remove: List[Tuple] = []
     if len(center) == 2:
         r0, c0 = center
         for node in list(G.nodes):
@@ -41,10 +141,11 @@ def apply_blackhole_defect(
         r0, c0, z0 = center
         for node in list(G.nodes):
             r, c, z = node[:3]
-            if math.sqrt((r - r0)**2 + (c - c0)**2 + (z - z0)**2) < radius:
+            if math.sqrt((r - r0) ** 2 + (c - c0) ** 2 + (z - z0) ** 2) < radius:
                 nodes_to_remove.append(node)
     G.remove_nodes_from(nodes_to_remove)
-    return nodes_to_remove
+    result = DefectResult(G, removed_nodes=tuple(nodes_to_remove))
+    return result if return_result else list(result.removed_nodes)
 
 def find_event_horizon(
     G: nx.Graph,
@@ -75,15 +176,37 @@ def find_event_horizon(
 def apply_defect(
     G: nx.Graph,
     defect_type: str = "wedge",
-    **kwargs
-) -> nx.Graph:
+    *,
+    return_removed: bool = False,
+    **kwargs,
+) -> nx.Graph | Tuple[nx.Graph, List]:
+    """Dispatch onto the requested defect helper.
+
+    Parameters
+    ----------
+    G:
+        Graph to mutate in-place.
+    defect_type:
+        One of ``"wedge"``, ``"blackhole"`` or ``"none"``.
+    return_removed:
+        If ``True`` the function returns ``(graph, removed_nodes)`` for
+        backwards compatibility with legacy call-sites that only required the
+        graph.  The more expressive :class:`DefectResult` is always returned to
+        callers using :func:`apply_wedge_defect` or :func:`apply_blackhole_defect`
+        directly.
+    **kwargs:
+        Forwarded to the specific defect helper.
     """
-    Dispatches to the appropriate defect function.
-    """
-    if defect_type == "wedge":
-        return apply_wedge_defect(G, **kwargs)
+
+    if defect_type == "none":
+        result = DefectResult(G)
+    elif defect_type == "wedge":
+        result = apply_wedge_defect(G, return_result=True, **kwargs)
     elif defect_type == "blackhole":
-        apply_blackhole_defect(G, **kwargs)
-        return G
-    # Add more defect types here in the future
-    return G
+        result = apply_blackhole_defect(G, return_result=True, **kwargs)
+    else:
+        raise ValueError(f"Unsupported defect type '{defect_type}'")
+
+    if return_removed:
+        return result.graph, list(result.removed_nodes)
+    return result.graph

--- a/tetrakis_sim/physics.py
+++ b/tetrakis_sim/physics.py
@@ -1,85 +1,152 @@
 
+from __future__ import annotations
+
+import warnings
+from typing import Dict, Hashable, Iterable, List, Optional, Tuple
+
 import numpy as np
+
+from .defects import apply_defect as _core_apply_defect
+from .plot import plot_fft as _plot_fft
+from .plot import plot_lattice as _plot_lattice
+
+
+class SimulationHistory(list):
+    """List-like container returned by :func:`run_wave_sim`."""
+
+    def __init__(
+        self,
+        states: Iterable[Dict[Hashable, float]],
+        *,
+        dt: float,
+        wave_speed: float,
+        metadata: Optional[Dict[str, float | bool]] = None,
+    ) -> None:
+        super().__init__(states)
+        self.dt = dt
+        self.wave_speed = wave_speed
+        self.metadata = metadata or {}
+
+
+def _coerce_initial_kick(nodes: List[Hashable], initial_data: Optional[Dict]) -> Dict:
+    """Ensure the lattice has an initial displacement to propagate."""
+
+    u = {n: 0.0 for n in nodes}
+    if initial_data:
+        u.update(initial_data)
+    elif nodes:
+        u[nodes[len(nodes) // 2]] = 1.0
+    return u
+
 
 def run_wave_sim(
     G,
-    steps=100,
-    initial_data=None,
-    c=1.0,          # wave speed
-    dt=0.2,         # time step size
-    damping=0.0,    # optional: add a little to see dissipation
-):
-    """
-    Discrete wave simulation on a graph (2D or 3D).
-    Uses a simple explicit finite-difference (FDTD) scheme.
-    
-    Args:
-        G: networkx.Graph
-        steps: number of time steps to run
-        initial_data: dict {node: value} (displacement at t=0)
-        c: wave speed (affects stability)
-        dt: time step size
-        damping: 0 = no damping, >0 = dissipates wave energy
-        
-    Returns:
-        hist: list of dicts (node -> displacement at each step)
-    """
-    nodes = list(G.nodes)
-    # 1. Initialize states (u: current, uprev: previous)
-    u = {n: 0.0 for n in nodes}
-    uprev = {n: 0.0 for n in nodes}
-    if initial_data:
-        for n, val in initial_data.items():
-            u[n] = val
-    # Small kick for a central node if not provided
-    if not initial_data:
-        n0 = nodes[len(nodes)//2]
-        u[n0] = 1.0
+    steps: int = 100,
+    initial_data: Optional[Dict] = None,
+    c: float = 1.0,
+    dt: float = 0.2,
+    damping: float = 0.0,
+) -> SimulationHistory:
+    """Simulate a discrete wave equation on the given lattice.
 
-    hist = [u.copy()]
-    for step in range(steps):
+    The method performs a stability check using a simple CFL-like criterion.
+    If the requested time step would be unstable it is automatically clamped
+    and a :class:`RuntimeWarning` is emitted.
+    """
+
+    nodes = list(G.nodes)
+    u = _coerce_initial_kick(nodes, initial_data)
+    uprev = {n: 0.0 for n in nodes}
+
+    max_degree = max((G.degree[n] for n in nodes), default=0)
+    effective_dt = float(dt)
+    metadata: Dict[str, float | bool] = {
+        "requested_dt": dt,
+        "wave_speed": c,
+        "max_degree": max_degree,
+        "damping": damping,
+    }
+
+    if max_degree > 0 and c > 0.0:
+        cfl_limit = float(1.0 / np.sqrt(max_degree))
+        metadata["stability_limit"] = cfl_limit
+        if c * effective_dt > cfl_limit:
+            effective_dt = cfl_limit / c
+            metadata["stability_adjusted"] = True
+            metadata["effective_dt"] = float(effective_dt)
+            warnings.warn(
+                (
+                    "Requested time-step is unstable for the current lattice "
+                    f"(c*dt={c * dt:.3f} > {cfl_limit:.3f}). Clamping dt to "
+                    f"{effective_dt:.3f}"
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    metadata.setdefault("stability_adjusted", False)
+    metadata.setdefault("effective_dt", float(effective_dt))
+
+    history: List[Dict[Hashable, float]] = [u.copy()]
+    coeff = (c * effective_dt) ** 2
+    for _ in range(steps):
         unew = {}
         for n in nodes:
             neighbor_sum = sum(u[nb] for nb in G.neighbors(n))
             deg = G.degree[n]
-            # Discrete wave equation on a graph
-            # u_next = 2u - u_prev + (c*dt)^2 * (Laplace_u)
-            lap = neighbor_sum - deg*u[n]
+            lap = neighbor_sum - deg * u[n]
             unew[n] = (
-                2*u[n] - uprev[n]
-                + (c*dt)**2 * lap
+                2 * u[n]
+                - uprev[n]
+                + coeff * lap
                 - damping * (u[n] - uprev[n])
             )
         uprev, u = u, unew
-        hist.append(u.copy())
-    return hist
+        history.append(u.copy())
+
+    return SimulationHistory(history, dt=effective_dt, wave_speed=c, metadata=metadata)
 
 
+def apply_defect(G, defect_type: str = "none", **kwargs) -> Tuple:
+    """Convenience wrapper around :func:`tetrakis_sim.defects.apply_defect`."""
 
-def apply_defect(G, defect_type="none"):
-    pass
-
-
-
+    return _core_apply_defect(G, defect_type=defect_type, return_removed=True, **kwargs)
 
 
-def run_fft(history, node=None):
-    """
-    Compute FFT for a specific node’s value over time.
-    history: list of dicts (node -> value), output from run_wave_sim
-    node: the node to analyze (tuple). If None, picks first node.
-    Returns: frequencies, spectrum (abs value), and the time-series values
-    """
+def run_fft(
+    history: Iterable[Dict[Hashable, float]],
+    node: Optional[Hashable] = None,
+    *,
+    dt: Optional[float] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute the FFT for a node across the simulation history."""
+
+    history_list = list(history)
+    if not history_list:
+        raise ValueError("Simulation history is empty")
+
+    sample_state = history_list[0]
     if node is None:
-        node = list(history[0].keys())[0]
-    values = np.array([state.get(node, 0.0) for state in history])
+        node = next(iter(sample_state.keys()))
+
+    inferred_dt = dt
+    if inferred_dt is None and hasattr(history, "dt"):
+        inferred_dt = getattr(history, "dt")
+    if inferred_dt is None:
+        inferred_dt = 1.0
+
+    values = np.array([state.get(node, 0.0) for state in history_list])
     spectrum = np.fft.fft(values)
-    freq = np.fft.fftfreq(len(values))
+    freq = np.fft.fftfreq(len(values), d=inferred_dt)
     return freq, np.abs(spectrum), values
 
 
-def plot_lattice(G, data=None):
-    pass
+def plot_lattice(G, data=None, **kwargs):
+    """Re-export for backwards compatibility with pre-0.2 physics API."""
 
-def plot_fft(data):
-    pass
+    return _plot_lattice(G, data=data, **kwargs)
+
+
+def plot_fft(freq, spectrum, *, node=None, values=None, **kwargs):
+    """Re-export for backwards compatibility with pre-0.2 physics API."""
+
+    return _plot_fft(freq, spectrum, node=node, values=values, **kwargs)


### PR DESCRIPTION
## Summary
- implement a metadata-aware SimulationHistory container, CFL guard, and FFT scaling fixes in the physics helpers
- finish the physics defect/plotting wrappers and expose defect metadata across the CLI and batch runner
- extend defect utilities to support 3-D wedges, keep backward-compatible return values, and add regression tests for the updated API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e75fd93b00833398d21536e7dcebba