### PR TITLE
Add CLI wave-sim parameters, record metadata, and silence plotting warnings by default

### DIFF
--- a/tetrakis_sim/cli.py
+++ b/tetrakis_sim/cli.py
@@ -12,6 +12,10 @@ def main():
     parser.add_argument("--defect", type=str, default="none", help="Defect type (none, wedge, blackhole, custom)")
     parser.add_argument("--physics", type=str, default="none", help="Physics model (none, wave, fft)")
     parser.add_argument("--plot", action="store_true", help="Visualize output")
+    parser.add_argument("--steps", type=int, default=100, help="Number of simulation steps")
+    parser.add_argument("--c", type=float, default=1.0, help="Wave speed for simulations")
+    parser.add_argument("--dt", type=float, default=0.2, help="Time step size for simulations")
+    parser.add_argument("--damping", type=float, default=0.0, help="Damping coefficient for simulations")
     args = parser.parse_args()
 
     # Build the lattice (2D or 3D)
@@ -46,9 +50,15 @@ def main():
     history = None
     fft_payload = None
     if args.physics in {"wave", "fft"}:
-        history = run_wave_sim(G)
+        history = run_wave_sim(
+            G,
+            steps=args.steps,
+            c=args.c,
+            dt=args.dt,
+            damping=args.damping,
+        )
         if args.physics == "fft":
-            freq, spectrum, values = run_fft(history)
+            freq, spectrum, values = run_fft(history, dt=history.dt)
             fft_payload = (freq, spectrum, values)
 
     if args.plot:
@@ -63,4 +73,5 @@ def main():
         f"Edges: {G.number_of_edges()}",
         f"Removed nodes: {len(removed_nodes)}",
     )
-
+    if history is not None:
+        print("Simulation metadata:", history.metadata)

--- a/tetrakis_sim/physics.py
+++ b/tetrakis_sim/physics.py
@@ -61,6 +61,7 @@ def run_wave_sim(
     max_degree = max((G.degree[n] for n in nodes), default=0)
     effective_dt = float(dt)
     metadata: Dict[str, float | bool] = {
+        "steps": steps,
         "requested_dt": dt,
         "wave_speed": c,
         "max_degree": max_degree,

--- a/tetrakis_sim/plot.py
+++ b/tetrakis_sim/plot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import os
 import warnings
 from typing import Any, List, Optional, Tuple
 
@@ -22,11 +23,6 @@ if _matplotlib_pkg is not None:
 if _mpl_spec is not None:
     plt = importlib.import_module("matplotlib.pyplot")
 else:  # pragma: no cover - only triggered when matplotlib is missing
-    warnings.warn(
-        "matplotlib is not installed; tetrakis_sim plotting functions will act as no-ops.",
-        RuntimeWarning,
-        stacklevel=2,
-    )
 
     class _AxesStub:
         def add_patch(self, *_args: Any, **_kwargs: Any) -> None:
@@ -44,6 +40,18 @@ else:  # pragma: no cover - only triggered when matplotlib is missing
     plt = _MatplotlibStub()
 
 _HAS_MATPLOTLIB = _mpl_spec is not None
+_WARNED_NO_MATPLOTLIB = False
+
+
+def _warn_no_matplotlib() -> None:
+    global _WARNED_NO_MATPLOTLIB
+    if not _WARNED_NO_MATPLOTLIB and os.getenv("TETRAKIS_SIM_WARN_NO_PLOTTING") == "1":
+        warnings.warn(
+            "matplotlib is not installed; tetrakis_sim plotting functions will act as no-ops.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        _WARNED_NO_MATPLOTLIB = True
 
 if _HAS_MATPLOTLIB:
     _mplot3d_spec = importlib.util.find_spec("mpl_toolkits.mplot3d")
@@ -59,11 +67,6 @@ if _plotly_pkg is not None:
 if _plotly_spec is not None:
     go = importlib.import_module("plotly.graph_objects")
 else:  # pragma: no cover - only triggered when plotly is missing
-    warnings.warn(
-        "plotly is not installed; 3-D plotting helpers will act as no-ops.",
-        RuntimeWarning,
-        stacklevel=2,
-    )
 
     class _PlotlyTraceStub:
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
@@ -91,6 +94,18 @@ else:  # pragma: no cover - only triggered when plotly is missing
     go = _PlotlyStub()
 
 _HAS_PLOTLY = _plotly_spec is not None
+_WARNED_NO_PLOTLY = False
+
+
+def _warn_no_plotly() -> None:
+    global _WARNED_NO_PLOTLY
+    if not _WARNED_NO_PLOTLY and os.getenv("TETRAKIS_SIM_WARN_NO_PLOTTING") == "1":
+        warnings.warn(
+            "plotly is not installed; 3-D plotting helpers will act as no-ops.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        _WARNED_NO_PLOTLY = True
 
 def plot_floor_with_circle(
     G: nx.Graph,
@@ -110,6 +125,7 @@ def plot_floor_with_circle(
     an analytical event horizon circle. Supports node coloring via 'data'.
     """
     if not _HAS_MATPLOTLIB:
+        _warn_no_matplotlib()
         return None
 
     nodes_on_layer = [n for n in G if n[2] == z]
@@ -168,6 +184,7 @@ def plot_lattice(G: nx.Graph, data=None, title: Optional[str] = None, figsize=(8
     Data can be a dict mapping nodes to color/size.
     """
     if not _HAS_MATPLOTLIB:
+        _warn_no_matplotlib()
         return None
 
     plt.figure(figsize=figsize)
@@ -204,6 +221,7 @@ def plot_fft(freq, spectrum, node=None, values=None):
     Plot the FFT amplitude spectrum. Optionally shows the time series.
     """
     if not _HAS_MATPLOTLIB:
+        _warn_no_matplotlib()
         return None
 
     plt.figure(figsize=(8, 3))
@@ -230,6 +248,7 @@ def plot_wave(time_steps, node_values, node=None):
     node_values should be a dict mapping node to array of values.
     """
     if not _HAS_MATPLOTLIB:
+        _warn_no_matplotlib()
         return None
 
     if node is None:
@@ -264,6 +283,7 @@ def plot_lattice_3d(
     title: plot title
     """
     if not _HAS_PLOTLY:
+        _warn_no_plotly()
         return None
 
     # Prepare data
@@ -344,6 +364,7 @@ def plot_3d_graph(G, node_size: int = 10, title: str = "3-D graph") -> None:
         Plot title.
     """
     if not _HAS_MATPLOTLIB:
+        _warn_no_matplotlib()
         return None
 
     xs, ys, zs = zip(*(G.nodes[n]["pos"] for n in G))
@@ -353,4 +374,3 @@ def plot_3d_graph(G, node_size: int = 10, title: str = "3-D graph") -> None:
     ax.set_title(title)
     ax.set_xlabel("x"); ax.set_ylabel("y"); ax.set_zlabel("z")
     plt.show()
-


### PR DESCRIPTION
### Motivation
- Allow users to precisely reproduce wave simulations by exposing key parameters to the CLI and recording them in the simulation metadata.
- Ensure FFT analysis uses the effective time-step produced by the wave solver so frequency results are correct after stability adjustments.
- Reduce noisy runtime warnings when optional plotting backends are not installed by making those warnings opt-in.

### Description
- Added CLI flags `--steps`, `--c`, `--dt`, and `--damping` in `tetrakis_sim/cli.py` and threaded them into the `run_wave_sim` invocation.
- Recorded the `steps` parameter in `SimulationHistory.metadata` inside `tetrakis_sim/physics.py` and passed the effective `dt` (`history.dt`) into `run_fft`.
- Print `history.metadata` from the CLI to expose requested parameters and any stability adjustments for reproducibility.
- Changed `tetrakis_sim/plot.py` to only emit missing-backend warnings when `TETRAKIS_SIM_WARN_NO_PLOTTING=1` and added helper stubs for quieter no-op plotting.

### Testing
- Ran the full test suite with `pytest` and all tests passed (`10 passed`).
- Verified the plotting-backend warning was suppressed by default and can be enabled via `TETRAKIS_SIM_WARN_NO_PLOTTING=1` if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948bf31b8ac8333a7fbcea9539a0b90)