### PR TITLE
Fix Prime-Helix Markdown Code Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ G = nx.Graph()
 add_prime_helix(G, n_rings=12, dtheta=0.14, pitch=2.0)  # 12 prime rings
 plot_3d_graph(G, node_size=16, title="Prime-helix (12 rings)")
 
+```
 
 <p align="center">
   <img src="docs/img/prime_helix_demo.png" alt="Prime-helix demo" width="400">


### PR DESCRIPTION
### Motivation
- Ensure the Prime-Helix demo example and image render correctly by separating the Python code block from the following HTML image block.
- Prevent the image HTML from being interpreted as part of the code block in `README.md`.

### Description
- Inserted a closing triple-backtick to `README.md` immediately after the demo Python snippet to end the code block.
- This is a one-line, documentation-only change to `README.md`.
- Committed the change with the message "Fix prime-helix markdown code block".

### Testing
- No automated tests were run because this is a docs-only change.
- Local verification consists of viewing the rendered README to confirm the code block and image display separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c7799db88333bb322bc36ef05e62)