### PR TITLE
Standardize CLI defect/physics options and add argparse choices

### DIFF
--- a/tetrakis_sim/cli.py
+++ b/tetrakis_sim/cli.py
@@ -9,8 +9,22 @@ def main():
     parser.add_argument("--dim", type=int, default=2, choices=[2, 3], help="Dimension of lattice (2 or 3)")
     parser.add_argument("--size", type=int, default=30, help="Grid size (NxN or NxNxN)")
     parser.add_argument("--layers", type=int, default=3, help="Number of layers for 3D grid (only used if --dim 3)")
-    parser.add_argument("--defect", type=str, default="none", help="Defect type (none, wedge, blackhole, custom)")
-    parser.add_argument("--physics", type=str, default="none", help="Physics model (none, wave, fft)")
+    parser.add_argument(
+        "--defect",
+        "--defect_type",
+        dest="defect_type",
+        type=str,
+        default="none",
+        choices=["none", "wedge", "blackhole", "custom"],
+        help="Defect type (none, wedge, blackhole, custom)",
+    )
+    parser.add_argument(
+        "--physics",
+        type=str,
+        default="none",
+        choices=["none", "wave", "fft"],
+        help="Physics model (none, wave, fft)",
+    )
     parser.add_argument("--plot", action="store_true", help="Visualize output")
     parser.add_argument("--steps", type=int, default=100, help="Number of simulation steps")
     parser.add_argument("--c", type=float, default=1.0, help="Wave speed for simulations")
@@ -27,22 +41,22 @@ def main():
     G = build_sheet(size=args.size, dim=args.dim, layers=args.layers)
 
     removed_nodes = []
-    if args.defect != "none":
+    if args.defect_type != "none":
         center_rc = (args.size // 2, args.size // 2)
         defect_kwargs = {}
-        if args.defect == "blackhole":
+        if args.defect_type == "blackhole":
             if args.dim == 3:
                 center = (center_rc[0], center_rc[1], args.layers // 2)
             else:
                 center = center_rc
             defect_kwargs = {"center": center, "radius": args.size / 4}
-        elif args.defect == "wedge":
+        elif args.defect_type == "wedge":
             defect_kwargs = {"center": center_rc}
             if args.dim == 3:
                 defect_kwargs["layer"] = args.layers // 2
         G, removed_nodes = apply_defect(
             G,
-            defect_type=args.defect,
+            defect_type=args.defect_type,
             return_removed=True,
             **defect_kwargs,
         )


### PR DESCRIPTION
### Motivation
- Enforce valid values for the CLI options to avoid invalid runtime inputs by adding explicit `choices` for `--defect` and `--physics`.
- Align the `tetrakis_sim/cli.py` argument naming with `scripts/run_batch.py` by standardizing on `defect_type`.
- Keep backwards-friendly usage by retaining `--defect` as an alias while using a single canonical name internally.
- Ensure defect handling code reads the standardized argument and constructs defect parameters consistently.

### Description
- Added a combined `--defect` / `--defect_type` argument with `dest="defect_type"` and `choices=["none","wedge","blackhole","custom"]` to the `argparse` setup.
- Added `choices=["none","wave","fft"]` to the `--physics` argument to restrict allowed physics models.
- Replaced internal references from `args.defect` to `args.defect_type` and passed `defect_type=args.defect_type` into `apply_defect`.
- Preserved existing simulation, FFT, and plotting behavior otherwise, keeping defaults and help text updated.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948cca9d5308333977241e3dde88963)