### PR TITLE
Use sieve for prime generation in prime_helix

### DIFF
--- a/tetrakis_sim/prime_helix.py
+++ b/tetrakis_sim/prime_helix.py
@@ -31,25 +31,28 @@ def _first_primes(count: int) -> List[int]:
     if count <= 0:
         return []
 
-    primes: List[int] = []
-    candidate = 2
+    if count < 6:
+        upper_bound = 15
+    else:
+        estimate = count * (math.log(count) + math.log(math.log(count)))
+        upper_bound = int(estimate) + 10
 
-    while len(primes) < count:
-        is_prime = True
-        limit = math.isqrt(candidate)
-        for p in primes:
-            if p > limit:
-                break
-            if candidate % p == 0:
-                is_prime = False
-                break
+    while True:
+        sieve = [True] * (upper_bound + 1)
+        sieve[0:2] = [False, False]
+        limit = math.isqrt(upper_bound)
+        for p in range(2, limit + 1):
+            if sieve[p]:
+                step_start = p * p
+                sieve[step_start:upper_bound + 1:p] = [False] * (
+                    ((upper_bound - step_start) // p) + 1
+                )
 
-        if is_prime:
-            primes.append(candidate)
+        primes = [i for i, is_prime in enumerate(sieve) if is_prime]
+        if len(primes) >= count:
+            return primes[:count]
 
-        candidate += 1 if candidate == 2 else 2  # skip even numbers > 2
-
-    return primes
+        upper_bound *= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- The previous prime generator used trial-division which is slow for larger `n_rings` and unnecessary for moderate counts.  
- A fast, robust prime sequence is useful for the `add_prime_helix` builder to support larger helix sizes.  

### Description

- Replaced the trial-division generator in `tetrakis_sim/prime_helix.py::_first_primes` with a sieve-based implementation (Sieve of Eratosthenes).  
- Added a simple upper-bound estimate using `n*(log n + log log n)` and a retry/doubling strategy to ensure enough primes are produced.  
- Retains behavior for small counts with a fixed small upper-bound and returns exactly the requested number of primes.  
- Changes are localized to `tetrakis_sim/prime_helix.py` and do not alter the public API (`add_prime_helix`).  

### Testing

- No automated tests were executed for this change.  
- Recommended command to run the test-suite: `pytest -q` to verify existing tests still pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c40c06a48333942e66681fd6f5a6)