### PR TITLE
Prime generation: switch to sieve; add `layer` option for 3D plotting

### DIFF
--- a/tetrakis_sim/prime_helix.py
+++ b/tetrakis_sim/prime_helix.py
@@ -31,25 +31,28 @@ def _first_primes(count: int) -> List[int]:
     if count <= 0:
         return []
 
-    primes: List[int] = []
-    candidate = 2
+    if count < 6:
+        upper_bound = 15
+    else:
+        estimate = count * (math.log(count) + math.log(math.log(count)))
+        upper_bound = int(estimate) + 10
 
-    while len(primes) < count:
-        is_prime = True
-        limit = math.isqrt(candidate)
-        for p in primes:
-            if p > limit:
-                break
-            if candidate % p == 0:
-                is_prime = False
-                break
+    while True:
+        sieve = [True] * (upper_bound + 1)
+        sieve[0:2] = [False, False]
+        limit = math.isqrt(upper_bound)
+        for p in range(2, limit + 1):
+            if sieve[p]:
+                step_start = p * p
+                sieve[step_start:upper_bound + 1:p] = [False] * (
+                    ((upper_bound - step_start) // p) + 1
+                )
 
-        if is_prime:
-            primes.append(candidate)
+        primes = [i for i, is_prime in enumerate(sieve) if is_prime]
+        if len(primes) >= count:
+            return primes[:count]
 
-        candidate += 1 if candidate == 2 else 2  # skip even numbers > 2
-
-    return primes
+        upper_bound *= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Improve performance and robustness of prime generation used by `add_prime_helix` for larger `n_rings` by avoiding slow trial division.  
- Make 3D plotting more ergonomic by enabling plotting of a single z-slice instead of silently refusing to render.  
- Keep public APIs (`add_prime_helix`) unchanged while making internal helpers more efficient and the plotting helper more flexible.  
- Reduce surprising behavior and provide clearer warnings when plotting 3D lattices without specifying a layer.

### Description

- Replace the trial-division prime generator in `tetrakis_sim/prime_helix.py::_first_primes` with a sieve-of-Eratosthenes implementation that uses an upper-bound estimate `n*(log n + log log n)` and a doubling retry to ensure enough primes are produced.  
- Add a `layer: Optional[int]` parameter to `tetrakis_sim/plot.py::plot_lattice` and implement logic to render a single z-slice for 3D lattices while providing clearer warnings when `layer` is not supplied.  
- Make `plot_lattice` handle empty graphs and unsupported node formats more safely by returning early or raising a `ValueError` for invalid node formats.  
- Changes are localized to `tetrakis_sim/prime_helix.py` and `tetrakis_sim/plot.py` and do not alter public top-level APIs like `add_prime_helix`.

### Testing

- Ran the full test-suite with `pytest -q`.  
- All tests passed: `10 passed` (no failures).  
- No additional integration tests were added for plotting or prime performance in this change.  
- Recommended manual checks: run `add_prime_helix(..., n_rings=...)` for larger `n_rings` and call `plot_lattice(G, layer=...)` for 3D graphs to validate visual output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c40c06a48333942e66681fd6f5a6)