### PR TITLE
Prime sieve, 3D plot layer support, and packaging metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
+from pathlib import Path
 from setuptools import setup, find_packages
+
+HERE = Path(__file__).parent
 
 setup(
     name="tetrakis_sim",
     version="0.1.0",
     packages=find_packages(),
+    install_requires=[
+        "networkx>=3.3,<4.0",
+        "numpy>=1.25,<2.0",
+    ],
+    description="Discrete geometry and wave physics on tetrakis-square lattices",
+    long_description=HERE.joinpath("README.md").read_text(encoding="utf-8"),
+    long_description_content_type="text/markdown",
 )
-

--- a/tetrakis_sim/prime_helix.py
+++ b/tetrakis_sim/prime_helix.py
@@ -31,25 +31,28 @@ def _first_primes(count: int) -> List[int]:
     if count <= 0:
         return []
 
-    primes: List[int] = []
-    candidate = 2
+    if count < 6:
+        upper_bound = 15
+    else:
+        estimate = count * (math.log(count) + math.log(math.log(count)))
+        upper_bound = int(estimate) + 10
 
-    while len(primes) < count:
-        is_prime = True
-        limit = math.isqrt(candidate)
-        for p in primes:
-            if p > limit:
-                break
-            if candidate % p == 0:
-                is_prime = False
-                break
+    while True:
+        sieve = [True] * (upper_bound + 1)
+        sieve[0:2] = [False, False]
+        limit = math.isqrt(upper_bound)
+        for p in range(2, limit + 1):
+            if sieve[p]:
+                step_start = p * p
+                sieve[step_start:upper_bound + 1:p] = [False] * (
+                    ((upper_bound - step_start) // p) + 1
+                )
 
-        if is_prime:
-            primes.append(candidate)
+        primes = [i for i, is_prime in enumerate(sieve) if is_prime]
+        if len(primes) >= count:
+            return primes[:count]
 
-        candidate += 1 if candidate == 2 else 2  # skip even numbers > 2
-
-    return primes
+        upper_bound *= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Improve prime generation performance and robustness used by the prime-helix builder for larger `n_rings` runs.
- Make 3-D plotting more ergonomic by allowing callers to render a single z-slice instead of silently refusing to draw.
- Surface clearer behavior for empty or unsupported graphs in the plotting helper.
- Provide basic packaging metadata and declare runtime dependencies for easier installation and PyPI packaging.

### Description

- Replace trial-division prime generation in `tetrakis_sim/prime_helix.py::_first_primes` with a sieve-of-Eratosthenes implementation that uses an upper-bound estimate and doubling retry to ensure enough primes are produced. 
- Add a `layer: Optional[int]` parameter to `tetrakis_sim/plot.py::plot_lattice` and implement logic to render a single z-slice for 3-D lattices while handling empty graphs and unsupported node formats safely. 
- Update `setup.py` to include `install_requires` (`networkx`, `numpy`), a short description, and `long_description` from `README.md` for better packaging metadata.

### Testing

- Ran the full test-suite with `pytest -q` and all tests passed (`10 passed`).
- No new automated tests were added for plotting or prime-performance in this change. 
- Recommend manual checks for `add_prime_helix(..., n_rings=...)` with larger `n_rings` and `plot_lattice(G, layer=...)` on 3-D graphs to validate visual output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c40c06a48333942e66681fd6f5a6)