### PR TITLE
Chore/one install one run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ lattice_floors/
 # Jupyter notebook temp/untitled files
 notebooks/Untitled*.ipynb
 
+
+# Local run outputs
+batch_cli_output/
+out_none/
+out_sing/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tetrakis-Sim: Discrete Geometry & Wave Physics
 
-**Author:** Mike Lawrenchuk
+**Author:** Mike Lawrenchuk  
 **Project:** [tetrakis-sim](https://github.com/MikeLawrenchuk/tetrakis-sim)
 
 ---
@@ -8,13 +8,13 @@
 ## Overview
 
 *Tetrakis-Sim* is a research-grade Python toolkit for discrete geometry, wave simulation, and spectral analysis on 2D/3D tetrakis-square lattices with advanced 
-defects (black holes, wedges, event horizons).
+defects (black holes, wedges, event horizons, naked singularities).
 
 **Features:**
 
 * Modular 2D/3D lattice and defect construction
 * Physics engine: wave propagation (FDTD) on arbitrary graphs
-* Black hole/event horizon and wedge defect modeling
+* Black hole/event horizon, wedge, and singularity defect modeling
 * Batch CLI for automated parameter sweeps
 * FFT, frequency mapping, mean spectrum, and advanced visualization
 * Professional workflow: Docker, reproducibility, batch logs, metadata
@@ -24,8 +24,7 @@ defects (black holes, wedges, event horizons).
 
 ## Prime-Helix Demo 🌐
 
-*Tetrakis-Sim* now includes a generator that winds the prime numbers into a
-3-D helix of taxicab “diamond” rings. A single helper call draws the graph:
+*Tetrakis-Sim* includes a generator that winds the prime numbers into a 3-D helix of taxicab “diamond” rings. A single helper call draws the graph:
 
 ```python
 from tetrakis_sim import add_prime_helix, plot_3d_graph
@@ -49,14 +48,8 @@ plot_3d_graph(G, node_size=16, title="Prime-helix (12 rings)")
 From the repo root:
 
 ```bash
-# Core dev tooling (pytest, black, ruff, mypy, etc.)
-pip install -e ".[dev]"
-
-# Optional plotting backends (matplotlib/plotly/kaleido)
-pip install -e ".[plot]"
-
-# Or install both at once:
-# pip install -e ".[dev,plot]"
+# Recommended: dev tooling + plotting backends
+python -m pip install -e ".[dev,plot]"
 ```
 
 ### 2. Run a Simulation with the Batch CLI
@@ -64,25 +57,33 @@ pip install -e ".[plot]"
 After installing editable mode, you can run the batch runner as a command:
 
 ```bash
-tetrakis-batch --size 11 --radius 2.5 --layers 7 --steps 50
+tetrakis-batch --dim 3 --size 11 --layers 7 --radius 2.5 --steps 50
 ```
 
 Backward-compatible (still works when running from a clone):
 
 ```bash
-python scripts/run_batch.py --size 11 --radius 2.5 --layers 7 --steps 50
+python scripts/run_batch.py --dim 3 --size 11 --layers 7 --radius 2.5 --steps 50
 ```
 
-**CLI arguments:**
+**CLI arguments (common):**
 
+* `--dim`: Lattice dimension (`2` or `3`)
 * `--size`: Lattice width/height (NxN)
-* `--radius`: Black hole radius
-* `--layers`: Number of 3D floors
+* `--layers`: Number of 3D floors (used when `--dim 3`)
 * `--steps`: Time steps
 * `--c`, `--dt`, `--damping`: Physics options
-* `--defect_type`: `blackhole`, `wedge`, `none`
+* `--defect_type`: `blackhole`, `wedge`, `singularity`, `none`
 * `--outdir`: Output directory (default: `batch_cli_output`)
 * `--prefix`: Custom prefix for all output files
+* `--kick`: Kick node tuple, e.g. `(3,5,3,'A')`
+
+**Singularity options (when `--defect_type singularity`):**
+
+* `--sing_mass`
+* `--sing_potential`
+* `--sing_radius`
+* `--sing_prune_edges`
 
 See all options:
 
@@ -97,7 +98,7 @@ tetrakis-batch --help
 ```bash
 for size in 7 9 11; do
   for radius in 1.5 2.5 3.5; do
-    tetrakis-batch --size $size --radius $radius --layers 5 --steps 40
+    tetrakis-batch --dim 3 --size $size --layers 5 --radius $radius --steps 40
   done
 done
 ```
@@ -120,39 +121,66 @@ Saved to `batch_cli_output/` (or as specified):
 
 * `notebooks/analyze_batch_outputs.ipynb`
 
-```python
-import glob, pandas as pd, numpy as np
+Example snippet:
 
-csv_files = glob.glob('batch_cli_output/*_spectrum.csv')
+```python
+import glob
+import re
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+csv_files = glob.glob("batch_cli_output/*_spectrum.csv")
 summary = []
+
 for f in csv_files:
-    import re
-    m = re.search(r'size(\d+)_radius([0-9.]+)', f)
-    size = int(m.group(1)); radius = float(m.group(2))
-    data = np.loadtxt(f, delimiter=',', skiprows=1)
-    freq, spectrum = data[:,0], data[:,1]
+    m = re.search(r"size(\d+)_radius([0-9.]+)", f)
+    if not m:
+        continue
+    size = int(m.group(1))
+    radius = float(m.group(2))
+
+    data = np.loadtxt(f, delimiter=",", skiprows=1)
+    freq, spectrum = data[:, 0], data[:, 1]
     dominant_freq = freq[np.argmax(spectrum)]
     summary.append({"file": f, "size": size, "radius": radius, "dominant_freq": dominant_freq})
-df = pd.DataFrame(summary).sort_values(["size","radius"])
-df.to_csv('batch_cli_output/batch_fft_summary.csv', index=False)
+
+df = pd.DataFrame(summary).sort_values(["size", "radius"])
+df.to_csv("batch_cli_output/batch_fft_summary.csv", index=False)
 print(df)
-```
 
-Plot dominant frequency vs. radius:
-
-```python
-for size in df['size'].unique():
-    subset = df[df['size']==size]
-    plt.plot(subset['radius'], subset['dominant_freq'], marker='o', label=f"size={size}")
-plt.xlabel("Black hole radius"); plt.ylabel("Dominant frequency"); plt.legend(); plt.show()
+# Plot dominant frequency vs. radius
+for size in df["size"].unique():
+    subset = df[df["size"] == size]
+    plt.plot(subset["radius"], subset["dominant_freq"], marker="o", label=f"size={size}")
+plt.xlabel("Black hole radius")
+plt.ylabel("Dominant frequency")
+plt.legend()
+plt.show()
 ```
 
 ---
 
-## Example: Advanced Run with Metadata
+## Example: Advanced 3D Run with Metadata
 
 ```bash
-tetrakis-batch --size 13 --radius 3.5 --layers 7 --steps 100 --c 1.5 --dt 0.15 --damping 0.02 --prefix "my_experiment"
+tetrakis-batch --dim 3 --size 13 --layers 7 \
+  --defect_type blackhole --radius 3.5 \
+  --steps 100 --c 1.5 --dt 0.15 --damping 0.02 \
+  --prefix "my_experiment"
+```
+
+Notes:
+- `--prefix` changes the output filenames (use `--outdir` to change the output folder; default is `batch_cli_output/`).
+- `--defect_type blackhole` is the default, but being explicit improves readability and reproducibility.
+
+## Example: Advanced 3D Singularity Run
+
+```bash
+tetrakis-batch --dim 3 --size 13 --layers 7 \
+  --defect_type singularity --sing_radius 1.5 --sing_mass 2000 --sing_prune_edges \
+  --steps 100 --dt 0.15 --damping 0.02 \
+  --prefix "my_singularity"
 ```
 
 ---
@@ -161,7 +189,7 @@ tetrakis-batch --size 13 --radius 3.5 --layers 7 --steps 100 --c 1.5 --dt 0.15 -
 
 * **Reproducible:** Every run saves all parameters and dominant frequencies as metadata.
 * **Flexible:** Parameter sweeps, custom physics, and batch runs are easy and automated.
-* **Publication-ready:** All output is compatible with pandas, matplotlib, and can be included in scientific papers, reports, or slides.
+* **Publication-ready:** All output is compatible with pandas/matplotlib and can be used in papers, reports, or slides.
 * **Professional CLI:** Friendly help, error-checking, and clear outputs.
 * **Docker-ready:** Build a reproducible environment for any machine with a single command.
 
@@ -177,7 +205,7 @@ tetrakis-batch --size 13 --radius 3.5 --layers 7 --steps 100 --c 1.5 --dt 0.15 -
 
 ## Contributing / Collaboration
 
-Pull requests, issues, and collaborations are welcome.
+Pull requests, issues, and collaborations are welcome.  
 If you are interested in research, teaching, or publishing with this code, please open an issue.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,10 @@ classifiers = [
 ]
 
 dependencies = [
-  "networkx>=3.0",
-  "numpy>=1.23",
+  "networkx>=3.3,<4.0",
+  "numpy>=1.25,<2.0",
 ]
+
 
 # Install with: pip install -e ".[dev,plot]"
 [project.optional-dependencies]
@@ -41,6 +42,8 @@ dev = [
   "jupyter>=1.0",
   "ipykernel>=6.0",
   "build>=1.0",
+  "ipywidgets>=8.1",
+
 ]
 plot = [
   "matplotlib>=3.7",

--- a/tetrakis_sim/cli.py
+++ b/tetrakis_sim/cli.py
@@ -1,23 +1,59 @@
 import argparse
-from tetrakis_sim.lattice import build_sheet  # , build_sheet_3d (for future 3D)
+import ast
+
+from tetrakis_sim.lattice import build_sheet
 from tetrakis_sim.defects import apply_defect
 from tetrakis_sim.physics import run_fft, run_wave_sim
 from tetrakis_sim.plot import plot_fft, plot_lattice
 
-def main():
-    parser = argparse.ArgumentParser(description="Tetrakis-Sim: Discrete Geometry Simulator")
-    parser.add_argument("--dim", type=int, default=2, choices=[2, 3], help="Dimension of lattice (2 or 3)")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Tetrakis-Sim: Discrete Geometry Simulator (quick interactive CLI)"
+    )
+
+    parser.add_argument("--dim", type=int, default=2, choices=[2, 3], help="Dimension (2 or 3)")
     parser.add_argument("--size", type=int, default=30, help="Grid size (NxN or NxNxN)")
-    parser.add_argument("--layers", type=int, default=3, help="Number of layers for 3D grid (only used if --dim 3)")
+    parser.add_argument(
+        "--layers",
+        type=int,
+        default=3,
+        help="Number of layers for 3D (used only if --dim 3)",
+    )
+
+    # Defects
     parser.add_argument(
         "--defect",
         "--defect_type",
         dest="defect_type",
         type=str,
         default="none",
-        choices=["none", "wedge", "blackhole", "custom"],
-        help="Defect type (none, wedge, blackhole, custom)",
+        choices=["none", "wedge", "blackhole", "singularity"],
+        help="Defect type (none, wedge, blackhole, singularity)",
     )
+    parser.add_argument(
+        "--radius",
+        type=float,
+        default=None,
+        help="Radius for blackhole (and default for singularity if --sing_radius not set)",
+    )
+
+    # Singularity parameters
+    parser.add_argument("--sing_mass", type=float, default=1000.0, help="Singularity mass")
+    parser.add_argument("--sing_potential", type=float, default=0.0, help="Singularity potential")
+    parser.add_argument(
+        "--sing_radius",
+        type=float,
+        default=None,
+        help="Singularity radius (default: use --radius; if both unset: 0.0)",
+    )
+    parser.add_argument(
+        "--sing_prune_edges",
+        action="store_true",
+        help="Prune edges for nodes within singularity radius",
+    )
+
+    # Physics
     parser.add_argument(
         "--physics",
         type=str,
@@ -25,35 +61,66 @@ def main():
         choices=["none", "wave", "fft"],
         help="Physics model (none, wave, fft)",
     )
-    parser.add_argument("--plot", action="store_true", help="Visualize output")
     parser.add_argument("--steps", type=int, default=100, help="Number of simulation steps")
-    parser.add_argument("--c", type=float, default=1.0, help="Wave speed for simulations")
-    parser.add_argument("--dt", type=float, default=0.2, help="Time step size for simulations")
-    parser.add_argument("--damping", type=float, default=0.0, help="Damping coefficient for simulations")
+    parser.add_argument("--c", type=float, default=1.0, help="Wave speed")
+    parser.add_argument("--dt", type=float, default=0.2, help="Time step size")
+    parser.add_argument("--damping", type=float, default=0.0, help="Damping")
+
+    # Kick + plotting
+    parser.add_argument(
+        "--kick",
+        type=str,
+        default=None,
+        help='Kick node tuple as a Python literal, e.g. "(10,10,\'A\')" or "(10,10,2,\'A\')"',
+    )
+    parser.add_argument("--plot", action="store_true", help="Visualize output")
+    parser.add_argument(
+        "--plot_layer",
+        type=int,
+        default=None,
+        help="For 3D plotting, which z-slice to render (default: center layer)",
+    )
+
     args = parser.parse_args()
 
-    # Build the lattice (2D or 3D)
-    # if args.dim == 3:
-    #    G = build_sheet_3d(size=args.size, layers=args.layers)
-    # else:
-    #    G = build_sheet(size=args.size)
-    
+    # Build lattice
     G = build_sheet(size=args.size, dim=args.dim, layers=args.layers)
 
+    # Choose geometric center
+    if args.dim == 2:
+        center = (args.size // 2, args.size // 2)
+    else:
+        center = (args.size // 2, args.size // 2, args.layers // 2)
+
+    # Apply defect
     removed_nodes = []
     if args.defect_type != "none":
-        center_rc = (args.size // 2, args.size // 2)
         defect_kwargs = {}
+
         if args.defect_type == "blackhole":
-            if args.dim == 3:
-                center = (center_rc[0], center_rc[1], args.layers // 2)
-            else:
-                center = center_rc
-            defect_kwargs = {"center": center, "radius": args.size / 4}
+            r = args.radius if args.radius is not None else (args.size / 4)
+            defect_kwargs = {"center": center, "radius": float(r)}
+
         elif args.defect_type == "wedge":
-            defect_kwargs = {"center": center_rc}
-            if args.dim == 3:
-                defect_kwargs["layer"] = args.layers // 2
+            if args.dim == 2:
+                defect_kwargs = {"center": center}
+            else:
+                defect_kwargs = {"center": center[:2], "layer": center[2]}
+
+        elif args.defect_type == "singularity":
+            sr = (
+                args.sing_radius
+                if args.sing_radius is not None
+                else (args.radius if args.radius is not None else 0.0)
+            )
+            defect_kwargs = {
+                "center": center,
+                "radius": float(sr),
+                "mass": float(args.sing_mass),
+                "potential": float(args.sing_potential),
+                "prune_edges": bool(args.sing_prune_edges),
+            }
+
         G, removed_nodes = apply_defect(
             G,
             defect_type=args.defect_type,
@@ -61,25 +128,57 @@ def main():
             **defect_kwargs,
         )
 
-    history = None
-    fft_payload = None
+    # Pick kick node (default: closest-to-center, connected, non-singular)
+    def _distance_sq(node):
+        r, c = node[:2]
+        return (r - center[0]) ** 2 + (c - center[1]) ** 2
+
+    initial_node = None
     if args.physics in {"wave", "fft"}:
+        if args.kick:
+            initial_node = ast.literal_eval(args.kick)
+            if initial_node not in G:
+                raise ValueError(f"--kick node {initial_node} is not in the graph")
+        else:
+            if args.dim == 3:
+                z = center[2]
+                nodes = [n for n in G if len(n) > 2 and n[2] == z]
+            else:
+                nodes = list(G.nodes)
+
+            candidates = [
+                n for n in nodes if G.degree[n] > 0 and not G.nodes[n].get("singular", False)
+            ]
+            pool = candidates if candidates else nodes
+            initial_node = min(pool, key=_distance_sq)
+
+    history = None
+    freq = spectrum = values = None
+
+    if args.physics in {"wave", "fft"}:
+        initial_data = {initial_node: 1.0} if initial_node is not None else None
         history = run_wave_sim(
             G,
             steps=args.steps,
+            initial_data=initial_data,
             c=args.c,
             dt=args.dt,
             damping=args.damping,
         )
+
         if args.physics == "fft":
-            freq, spectrum, values = run_fft(history, dt=history.dt)
-            fft_payload = (freq, spectrum, values)
+            freq, spectrum, values = run_fft(history, node=initial_node)
 
     if args.plot:
         final_state = history[-1] if history else None
-        plot_lattice(G, data=final_state)
-        if fft_payload is not None:
-            plot_fft(*fft_payload)
+        if args.dim == 3:
+            layer = args.plot_layer if args.plot_layer is not None else center[2]
+            plot_lattice(G, data=final_state, layer=layer)
+        else:
+            plot_lattice(G, data=final_state)
+
+        if freq is not None and spectrum is not None:
+            plot_fft(freq, spectrum, node=initial_node, values=values)
 
     print(
         "Done!",
@@ -87,5 +186,18 @@ def main():
         f"Edges: {G.number_of_edges()}",
         f"Removed nodes: {len(removed_nodes)}",
     )
+    if initial_node is not None:
+        print(
+            "kick node:",
+            initial_node,
+            "degree:",
+            G.degree[initial_node],
+            "singular:",
+            G.nodes[initial_node].get("singular", False),
+        )
     if history is not None:
         print("Simulation metadata:", history.metadata)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR tightens up the “first 5 minutes” experience for tetrakis-sim:

- README now shows one recommended install command: `python -m pip install -e ".[dev,plot]"`
- Batch CLI examples are explicitly 3D when using `--layers` (adds `--dim 3`)
- Documented/added singularity runs alongside blackhole runs
- `tetrakis-sim` CLI updated to support `singularity`, deterministic `--kick`, and 3D plotting via `--plot_layer`
- Docker image now installs the package via `pyproject.toml` (so `tetrakis-batch` / `tetrakis-sim` console scripts exist inside the container)

## How to test
### Local (macOS)
- `python -m pip install -e ".[dev,plot]"`
- `pytest`
- `tetrakis-batch --help`
- Example run:
  - `tetrakis-batch --dim 3 --size 11 --layers 7 --radius 2.5 --steps 50`

### Docker (no host mounts required)
- `docker build -t tetrakis-sim .`
- `docker run --rm tetrakis-sim tetrakis-batch --help`
- `docker run --rm tetrakis-sim bash -lc 'mkdir -p /tmp/out && tetrakis-batch --dim 3 --size 11 --layers 7 --radius 2.5 --steps 50 --outdir /tmp/out && ls -lh /tmp/out'`

## Notes
I did not remove legacy `requirements*.txt` / `setup.py` in this PR to keep the change set focused. Those can be cleaned up in a follow-up PR once this lands.
