### PR TITLE
Evals: add tetrakis-eval console script and CLI skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tetrakis-batch = "tetrakis_sim.batch:main"
 
 
 
+tetrakis-eval = "tetrakis_sim.evals.cli:main"
 [project.urls]
 Homepage = "https://mikelawrenchuk.github.io/"
 Repository = "https://github.com/MikeLawrenchuk/tetrakis-sim"

--- a/tetrakis_sim/evals/__init__.py
+++ b/tetrakis_sim/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation harness package for tetrakis-sim."""

--- a/tetrakis_sim/evals/cli.py
+++ b/tetrakis_sim/evals/cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tetrakis-eval",
+        description="Evaluation harness for tetrakis-sim (dataset generation + baseline scoring).",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("generate", help="Generate an eval dataset (JSONL)")
+    g.add_argument("--out", required=True, help="Output JSONL path")
+
+    b = sub.add_parser("baseline", help="Run a baseline model on a dataset")
+    b.add_argument("--data", required=True, help="Input JSONL path")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.cmd == "generate":
+        print("Not implemented yet (Milestone 3).")
+        print(f"Requested output: {args.out}")
+        return 0
+
+    if args.cmd == "baseline":
+        print("Not implemented yet (Milestone 3).")
+        print(f"Requested dataset: {args.data}")
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary

Adds tetrakis-eval console script entrypoint
Adds tetrakis_sim.evals package with CLI skeleton (generate, baseline)

Notes
Subcommands are placeholders; implementation lands in Milestone 3
CI checks should pass unchanged