### PR TITLE
Evals: implement dataset generator + baseline scorer + smoke test

### DIFF
--- a/tests/test_evals_smoke.py
+++ b/tests/test_evals_smoke.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from tetrakis_sim.evals.baseline import run_nearest_centroid_baseline
+from tetrakis_sim.evals.dataset import generate_defect_classification_jsonl
+
+
+def test_evals_smoke(tmp_path: Path) -> None:
+    out = tmp_path / "defect_classification.jsonl"
+    generate_defect_classification_jsonl(
+        out,
+        n_per_class=1,
+        seed=0,
+        size=7,
+        dim=2,
+        layers=1,
+        steps=5,
+        c=1.0,
+        dt=0.2,
+        damping=0.0,
+    )
+    metrics = run_nearest_centroid_baseline(out, seed=0, test_frac=0.5)
+    assert 0.0 <= metrics["accuracy"] <= 1.0

--- a/tetrakis_sim/evals/baseline.py
+++ b/tetrakis_sim/evals/baseline.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import math
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    path = Path(path)
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def _feature_keys(rows: list[dict[str, Any]]) -> list[str]:
+    keys: set[str] = set()
+    for r in rows:
+        keys.update((r.get("features") or {}).keys())
+    return sorted(keys)
+
+
+def _vectorize(
+    rows: list[dict[str, Any]], keys: list[str]
+) -> tuple[np.ndarray, list[str]]:
+    X = np.zeros((len(rows), len(keys)), dtype=float)
+    y: list[str] = []
+    for i, r in enumerate(rows):
+        y.append(str(r.get("label")))
+        feats = r.get("features") or {}
+        for j, k in enumerate(keys):
+            X[i, j] = float(feats.get(k, 0.0))
+    return X, y
+
+
+def _split(n: int, *, seed: int, test_frac: float) -> tuple[list[int], list[int]]:
+    idx = list(range(n))
+    rng = random.Random(seed)
+    rng.shuffle(idx)
+    n_test = max(1, int(math.floor(test_frac * n)))
+    test_idx = idx[:n_test]
+    train_idx = idx[n_test:]
+    if not train_idx:
+        train_idx = test_idx
+    return train_idx, test_idx
+
+
+def run_nearest_centroid_baseline(
+    data_path: str | Path,
+    *,
+    seed: int = 0,
+    test_frac: float = 0.3,
+) -> dict[str, float]:
+    rows = _load_jsonl(data_path)
+    if not rows:
+        raise ValueError("Dataset is empty")
+
+    keys = _feature_keys(rows)
+    X, y = _vectorize(rows, keys)
+
+    train_idx, test_idx = _split(len(rows), seed=seed, test_frac=test_frac)
+    Xtr = X[train_idx]
+    ytr = [y[i] for i in train_idx]
+    Xte = X[test_idx]
+    yte = [y[i] for i in test_idx]
+
+    labels = sorted(set(ytr))
+    centroids: dict[str, np.ndarray] = {}
+    for lab in labels:
+        mask = np.array([yy == lab for yy in ytr], dtype=bool)
+        centroids[lab] = Xtr[mask].mean(axis=0) if mask.any() else Xtr.mean(axis=0)
+
+    correct = 0
+    for i in range(len(Xte)):
+        x = Xte[i]
+        best_lab = None
+        best_d = None
+        for lab, c in centroids.items():
+            d = float(np.linalg.norm(x - c))
+            if best_d is None or d < best_d:
+                best_d = d
+                best_lab = lab
+        if best_lab == yte[i]:
+            correct += 1
+
+    acc = float(correct / max(1, len(Xte)))
+
+    return {
+        "n": float(len(rows)),
+        "n_train": float(len(train_idx)),
+        "n_test": float(len(test_idx)),
+        "accuracy": acc,
+    }

--- a/tetrakis_sim/evals/cli.py
+++ b/tetrakis_sim/evals/cli.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
+
+from .baseline import run_nearest_centroid_baseline
+from .dataset import generate_defect_classification_jsonl
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -12,9 +16,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     g = sub.add_parser("generate", help="Generate an eval dataset (JSONL)")
     g.add_argument("--out", required=True, help="Output JSONL path")
+    g.add_argument("--n-per-class", type=int, default=10)
+    g.add_argument("--seed", type=int, default=0)
+    g.add_argument("--size", type=int, default=11)
+    g.add_argument("--dim", type=int, default=2, choices=[2, 3])
+    g.add_argument("--layers", type=int, default=5)
+    g.add_argument("--steps", type=int, default=40)
+    g.add_argument("--c", type=float, default=1.0)
+    g.add_argument("--dt", type=float, default=0.2)
+    g.add_argument("--damping", type=float, default=0.0)
 
-    b = sub.add_parser("baseline", help="Run a baseline model on a dataset")
+    b = sub.add_parser("baseline", help="Run a nearest-centroid baseline")
     b.add_argument("--data", required=True, help="Input JSONL path")
+    b.add_argument("--seed", type=int, default=0)
+    b.add_argument("--test-frac", type=float, default=0.3)
 
     return parser
 
@@ -24,13 +39,30 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.cmd == "generate":
-        print("Not implemented yet (Milestone 3).")
-        print(f"Requested output: {args.out}")
+        out = Path(args.out)
+        path = generate_defect_classification_jsonl(
+            out,
+            n_per_class=args.n_per_class,
+            seed=args.seed,
+            size=args.size,
+            dim=args.dim,
+            layers=args.layers,
+            steps=args.steps,
+            c=args.c,
+            dt=args.dt,
+            damping=args.damping,
+        )
+        print(f"wrote: {path}")
         return 0
 
     if args.cmd == "baseline":
-        print("Not implemented yet (Milestone 3).")
-        print(f"Requested dataset: {args.data}")
+        metrics = run_nearest_centroid_baseline(
+            args.data,
+            seed=args.seed,
+            test_frac=args.test_frac,
+        )
+        for k in sorted(metrics):
+            print(f"{k}: {metrics[k]}")
         return 0
 
     return 2

--- a/tetrakis_sim/evals/dataset.py
+++ b/tetrakis_sim/evals/dataset.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+from tetrakis_sim.defects import apply_defect
+from tetrakis_sim.lattice import build_sheet
+from tetrakis_sim.physics import run_fft, run_wave_sim
+
+from .features import spectral_features, timeseries_features
+
+
+def _center_for(size: int, dim: int, layers: int) -> tuple[int, ...]:
+    if dim == 2:
+        return (size // 2, size // 2)
+    return (size // 2, size // 2, layers // 2)
+
+
+def _pick_kick_node(G: Any, center: tuple[int, ...], dim: int) -> Any:
+    if dim == 3:
+        z = center[2]
+        nodes = [n for n in G.nodes if len(n) > 3 and n[2] == z]
+    else:
+        nodes = list(G.nodes)
+
+    if not nodes:
+        raise RuntimeError("No nodes available to kick")
+
+    def dist2(node: Any) -> int:
+        r, c = node[:2]
+        return (r - center[0]) ** 2 + (c - center[1]) ** 2
+
+    candidates = [
+        n
+        for n in nodes
+        if G.degree[n] > 0 and not bool(G.nodes[n].get("singular", False))
+    ]
+    pool = candidates if candidates else nodes
+    return min(pool, key=dist2)
+
+
+def _graph_features(G: Any, removed_nodes: list[Any]) -> dict[str, float]:
+    n = float(G.number_of_nodes())
+    m = float(G.number_of_edges())
+    avg_degree = float((2.0 * m / n) if n > 0 else 0.0)
+    max_degree = float(max((G.degree[v] for v in G.nodes), default=0))
+    singular_count = float(
+        sum(1 for v in G.nodes if bool(G.nodes[v].get("singular", False)))
+    )
+    return {
+        "n_nodes": n,
+        "n_edges": m,
+        "avg_degree": avg_degree,
+        "max_degree": max_degree,
+        "removed_node_count": float(len(removed_nodes)),
+        "singular_node_count": singular_count,
+    }
+
+
+def generate_defect_classification_jsonl(
+    out_path: str | Path,
+    *,
+    n_per_class: int = 10,
+    seed: int = 0,
+    size: int = 11,
+    dim: int = 2,
+    layers: int = 5,
+    steps: int = 40,
+    c: float = 1.0,
+    dt: float = 0.2,
+    damping: float = 0.0,
+) -> Path:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rng = random.Random(seed)
+    defect_types = ["none", "wedge", "blackhole", "singularity"]
+
+    records: list[dict[str, Any]] = []
+    idx = 0
+
+    for defect_type in defect_types:
+        for _ in range(int(n_per_class)):
+            idx += 1
+
+            G = build_sheet(size=size, dim=dim, layers=layers)
+            center = _center_for(size=size, dim=dim, layers=layers)
+
+            params: dict[str, Any] = {
+                "size": size,
+                "dim": dim,
+                "layers": layers,
+                "steps": steps,
+                "c": c,
+                "dt": dt,
+                "damping": damping,
+            }
+
+            defect_kwargs: dict[str, Any] = {}
+            if defect_type == "blackhole":
+                r = float(rng.choice([1.5, 2.0, 2.5]))
+                defect_kwargs = {"center": center, "radius": r}
+                params.update({"radius": r})
+            elif defect_type == "wedge":
+                if dim == 2:
+                    defect_kwargs = {"center": center}
+                else:
+                    defect_kwargs = {"center": center[:2], "layer": center[2]}
+                    params.update({"layer": int(center[2])})
+            elif defect_type == "singularity":
+                sr = float(rng.choice([0.0, 0.5, 1.0]))
+                mass = float(rng.choice([50.0, 200.0, 1000.0]))
+                pot = float(rng.choice([0.0, 25.0]))
+                prune = bool(rng.choice([False, True]))
+                defect_kwargs = {
+                    "center": center,
+                    "radius": sr,
+                    "mass": mass,
+                    "potential": pot,
+                    "prune_edges": prune,
+                }
+                params.update(
+                    {"radius": sr, "mass": mass, "potential": pot, "prune_edges": prune}
+                )
+
+            removed_nodes: list[Any] = []
+            if defect_type != "none":
+                G, removed_nodes = apply_defect(
+                    G, defect_type=defect_type, return_removed=True, **defect_kwargs
+                )
+
+            kick = _pick_kick_node(G, center=center, dim=dim)
+
+            history = run_wave_sim(
+                G,
+                steps=steps,
+                initial_data={kick: 1.0},
+                c=c,
+                dt=dt,
+                damping=damping,
+            )
+
+            freq, amp, values = run_fft(history, node=kick)
+
+            feats: dict[str, float] = {}
+            feats.update(_graph_features(G, removed_nodes))
+            feats.update(spectral_features(freq, amp))
+            feats.update(timeseries_features(values))
+            feats["kick_degree"] = float(G.degree[kick])
+            feats["kick_dist2_center"] = float(
+                (kick[0] - center[0]) ** 2 + (kick[1] - center[1]) ** 2
+            )
+
+            rec = {
+                "id": f"dc_{idx:05d}",
+                "task": "defect_classification",
+                "label": defect_type,
+                "params": params,
+                "features": feats,
+            }
+            records.append(rec)
+
+    with out_path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, sort_keys=True) + "\n")
+
+    return out_path

--- a/tetrakis_sim/evals/features.py
+++ b/tetrakis_sim/evals/features.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def spectral_features(freq: Any, amp: Any) -> dict[str, float]:
+    f = np.asarray(freq, dtype=float)
+    a = np.asarray(amp, dtype=float)
+
+    if f.shape != a.shape:
+        raise ValueError("freq and amp must have the same shape")
+
+    mask = f >= 0
+    f = np.abs(f[mask])
+    a = a[mask]
+
+    s = float(a.sum())
+    if a.size == 0 or s <= 0.0:
+        return {
+            "dominant_freq": 0.0,
+            "spectral_centroid": 0.0,
+            "spectral_bandwidth": 0.0,
+            "peak_amplitude": 0.0,
+        }
+
+    peak_idx = int(np.argmax(a))
+    dominant = float(f[peak_idx])
+
+    centroid = float((f * a).sum() / s)
+    bandwidth = float(np.sqrt(((f - centroid) ** 2 * a).sum() / s))
+
+    return {
+        "dominant_freq": dominant,
+        "spectral_centroid": centroid,
+        "spectral_bandwidth": bandwidth,
+        "peak_amplitude": float(a.max()),
+    }
+
+
+def timeseries_features(values: Any) -> dict[str, float]:
+    v = np.asarray(values, dtype=float)
+    if v.size == 0:
+        return {"ts_rms": 0.0, "ts_peak": 0.0}
+    return {
+        "ts_rms": float(np.sqrt(np.mean(v**2))),
+        "ts_peak": float(np.max(np.abs(v))),
+    }


### PR DESCRIPTION
Adds tetrakis-eval generate to produce JSONL eval datasets
Adds tetrakis-eval baseline nearest-centroid scorer + metrics output
Adds smoke test to ensure dataset generation + baseline run end-to-end
Keeps CI green (ruff/black/mypy/pytest)
