### PR TITLE
Performance: add wave benchmark + baseline results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ out_sing/
 *.bak.*
 
 .pre-commit-config.yaml.bad.*
+
+# Benchmark outputs
+bench_*.csv

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -21,7 +21,7 @@ Fill this in when you record results:
 - Python:
 - Install method: (e.g., pip install -e ".[dev]")
 
-## Recommended baseline runs
+## Baseline runs (before optimization)
 
 2D baseline:
 
@@ -36,23 +36,28 @@ Notes:
 
 ## Results
 
-### 2D
+### 2D (steps=50, repeats=3, dt=0.1)
 
 | size | nodes | edges | steps | repeats | sim_s_median | effective_dt | stability_adjusted |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| | | | | | | | |
+| 11 | 484 | 5,566 | 50 | 3 | 0.051075 | 0.100000 | 0 |
+| 21 | 1,764 | 37,926 | 50 | 3 | 0.278252 | 0.100000 | 0 |
+| 31 | 3,844 | 121,086 | 50 | 3 | 0.820960 | 0.100000 | 0 |
+| 41 | 6,724 | 279,046 | 50 | 3 | 1.828803 | 0.100000 | 0 |
 
-### 3D
+### 3D (layers=5, steps=30, repeats=3, dt=0.1)
 
 | size | layers | nodes | edges | steps | repeats | sim_s_median | effective_dt | stability_adjusted |
 |---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| | | | | | | | | |
+| 7 | 5 | 980 | 8,134 | 30 | 3 | 0.057394 | 0.100000 | 0 |
+| 11 | 5 | 2,420 | 29,766 | 30 | 3 | 0.182789 | 0.100000 | 0 |
+| 15 | 5 | 4,500 | 73,350 | 30 | 3 | 0.402404 | 0.100000 | 0 |
 
 ## Bottleneck hypothesis
 
 run_wave_sim iterates over nodes and sums neighbor values each step, so runtime is expected to be dominated by Python-level loops for larger graphs.
 
-## Optimization plan (to be filled)
+## Optimization plan (next)
 
 - Change:
 - Before/after command:

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,60 @@
+# Performance
+
+This note records benchmark commands and measured results for build_sheet and run_wave_sim.
+
+## Benchmark script
+
+Command:
+
+    python scripts/bench_wave.py | tee bench.csv
+
+The output is CSV with one row per lattice size.
+
+## Machine
+
+Fill this in when you record results:
+
+- Model:
+- CPU:
+- RAM:
+- OS:
+- Python:
+- Install method: (e.g., pip install -e ".[dev]")
+
+## Recommended baseline runs
+
+2D baseline:
+
+    python scripts/bench_wave.py --dim 2 --sizes 11,21,31,41 --steps 50 --repeats 3 --dt 0.1 | tee bench_2d_before.csv
+
+3D baseline:
+
+    python scripts/bench_wave.py --dim 3 --layers 5 --sizes 7,11,15 --steps 30 --repeats 3 --dt 0.1 | tee bench_3d_before.csv
+
+Notes:
+- If stability_adjusted=1, dt was clamped internally. For fair comparisons, use the same effective_dt.
+
+## Results
+
+### 2D
+
+| size | nodes | edges | steps | repeats | sim_s_median | effective_dt | stability_adjusted |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| | | | | | | | |
+
+### 3D
+
+| size | layers | nodes | edges | steps | repeats | sim_s_median | effective_dt | stability_adjusted |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| | | | | | | | | |
+
+## Bottleneck hypothesis
+
+run_wave_sim iterates over nodes and sums neighbor values each step, so runtime is expected to be dominated by Python-level loops for larger graphs.
+
+## Optimization plan (to be filled)
+
+- Change:
+- Before/after command:
+- Before/after tables:
+- Correctness checks run (pytest / invariants):

--- a/scripts/bench_wave.py
+++ b/scripts/bench_wave.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+import warnings
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from tetrakis_sim.lattice import build_sheet
+from tetrakis_sim.physics import run_wave_sim
+
+
+@dataclass(frozen=True)
+class BenchRow:
+    dim: int
+    layers: int
+    size: int
+    nodes: int
+    edges: int
+    max_degree: int
+    build_s: float
+    sim_s_median: float
+    sim_s_min: float
+    sim_s_max: float
+    effective_dt: float
+    stability_adjusted: bool
+
+
+def _parse_int_list(parts: Sequence[str]) -> list[int]:
+    out: list[int] = []
+    for item in parts:
+        for token in item.split(","):
+            token = token.strip()
+            if token:
+                out.append(int(token))
+    return out
+
+
+def _kick_node(*, size: int, dim: int, layers: int):
+    if dim == 2:
+        return (size // 2, size // 2, "A")
+    return (size // 2, size // 2, layers // 2, "A")
+
+
+def bench_one(
+    *,
+    size: int,
+    dim: int,
+    layers: int,
+    steps: int,
+    c: float,
+    dt: float,
+    damping: float,
+    repeats: int,
+) -> BenchRow:
+    t0 = time.perf_counter()
+    G = build_sheet(size=size, dim=dim, layers=layers)
+    build_s = time.perf_counter() - t0
+
+    kick = _kick_node(size=size, dim=dim, layers=layers)
+    initial_data = {kick: 1.0}
+
+    sim_times: list[float] = []
+    effective_dt = float(dt)
+    stability_adjusted = False
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        for _ in range(int(repeats)):
+            t1 = time.perf_counter()
+            hist = run_wave_sim(
+                G,
+                steps=int(steps),
+                initial_data=initial_data,
+                c=float(c),
+                dt=float(dt),
+                damping=float(damping),
+            )
+            sim_times.append(time.perf_counter() - t1)
+
+            effective_dt = float(hist.dt)
+            stability_adjusted = bool(hist.metadata.get("stability_adjusted", False))
+
+    nodes = list(G.nodes)
+    max_degree = max((G.degree[n] for n in nodes), default=0)
+
+    return BenchRow(
+        dim=int(dim),
+        layers=int(layers if dim == 3 else 1),
+        size=int(size),
+        nodes=int(G.number_of_nodes()),
+        edges=int(G.number_of_edges()),
+        max_degree=int(max_degree),
+        build_s=float(build_s),
+        sim_s_median=float(statistics.median(sim_times)),
+        sim_s_min=float(min(sim_times)),
+        sim_s_max=float(max(sim_times)),
+        effective_dt=float(effective_dt),
+        stability_adjusted=bool(stability_adjusted),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Benchmark build_sheet + run_wave_sim scaling.")
+    p.add_argument("--sizes", nargs="+", default=["11,21,31"], help="Comma-separated sizes.")
+    p.add_argument("--dim", type=int, choices=[2, 3], default=2)
+    p.add_argument("--layers", type=int, default=5, help="Used only when --dim 3.")
+    p.add_argument("--steps", type=int, default=50)
+    p.add_argument("--repeats", type=int, default=3)
+    p.add_argument("--c", type=float, default=1.0)
+    p.add_argument("--dt", type=float, default=0.1)
+    p.add_argument("--damping", type=float, default=0.0)
+    args = p.parse_args(argv)
+
+    sizes = _parse_int_list(args.sizes)
+    if not sizes:
+        raise SystemExit("No sizes provided.")
+
+    print(
+        "dim,layers,size,nodes,edges,max_degree,build_s,sim_s_median,sim_s_min,sim_s_max,effective_dt,stability_adjusted"
+    )
+    for s in sizes:
+        row = bench_one(
+            size=s,
+            dim=args.dim,
+            layers=args.layers,
+            steps=args.steps,
+            c=args.c,
+            dt=args.dt,
+            damping=args.damping,
+            repeats=args.repeats,
+        )
+        print(
+            f"{row.dim},{row.layers},{row.size},{row.nodes},{row.edges},{row.max_degree},"
+            f"{row.build_s:.6f},{row.sim_s_median:.6f},{row.sim_s_min:.6f},{row.sim_s_max:.6f},"
+            f"{row.effective_dt:.6f},{int(row.stability_adjusted)}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_wave_smoke.py
+++ b/tests/test_bench_wave_smoke.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_bench_wave_script_runs_and_emits_csv():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "bench_wave.py"
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--dim",
+        "2",
+        "--sizes",
+        "5",
+        "--steps",
+        "2",
+        "--repeats",
+        "1",
+        "--dt",
+        "0.05",
+    ]
+
+    env = dict(os.environ)
+    env.setdefault("MPLBACKEND", "Agg")
+
+    proc = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, (proc.stdout or "") + (proc.stderr or "")
+
+    lines = [ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()]
+    assert lines, "Expected CSV output."
+    assert lines[0].startswith("dim,layers,size,"), f"Unexpected header: {lines[0]}"
+    assert len(lines) >= 2, "Expected at least one data row."


### PR DESCRIPTION
Summary
Adds a reproducible benchmark script and a performance note with baseline measurements for build_sheet + run_wave_sim.

Changes
Add scripts/bench_wave.py (CSV benchmark output for size/dim/steps)
Add docs/performance.md with baseline results (2D and 3D) and commands to reproduce
Add tests/test_bench_wave_smoke.py smoke test to ensure the benchmark script runs and emits CSV

Reproduce

2D baseline:

python scripts/bench_wave.py --dim 2 --sizes 11,21,31,41 --steps 50 --repeats 3 --dt 0.1 | tee bench_2d_before.csv

3D baseline:

python scripts/bench_wave.py --dim 3 --layers 5 --sizes 7,11,15 --steps 30 --repeats 3 --dt 0.1 | tee bench_3d_before.csv

Verification

pre-commit run --all-files
pytest -q


