### PR TITLE
feat: harden eval harness (features, baseline, schema, streaming)

### DIFF
--- a/tests/test_evals_cli.py
+++ b/tests/test_evals_cli.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tetrakis_sim.evals.cli import main as eval_main
+
+
+def test_evals_cli_smoke(tmp_path: Path) -> None:
+    out = tmp_path / "dc.jsonl"
+
+    rc = eval_main(
+        [
+            "generate",
+            "--out",
+            str(out),
+            "--n-per-class",
+            "1",
+            "--seed",
+            "1",
+            "--size",
+            "7",
+            "--dim",
+            "2",
+            "--steps",
+            "10",
+            "--dt",
+            "0.1",
+        ]
+    )
+    assert rc == 0
+    assert out.exists()
+
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 4  # 4 classes * n-per-class=1
+
+    rec0 = json.loads(lines[0])
+    assert rec0["schema_version"] == 1
+    assert "features" in rec0
+    assert "params" in rec0
+    assert "dt_requested" in rec0["params"]
+    assert "dt_used" in rec0["params"]
+
+    rc2 = eval_main(["baseline", "--data", str(out), "--seed", "1", "--test-frac", "0.5"])
+    assert rc2 == 0

--- a/tetrakis_sim/evals/features.py
+++ b/tetrakis_sim/evals/features.py
@@ -4,6 +4,9 @@ from typing import Any
 
 import numpy as np
 
+_TOPK = 5
+_EPS = 1e-12
+
 
 def spectral_features(freq: Any, amp: Any) -> dict[str, float]:
     f = np.asarray(freq, dtype=float)
@@ -12,18 +15,24 @@ def spectral_features(freq: Any, amp: Any) -> dict[str, float]:
     if f.shape != a.shape:
         raise ValueError("freq and amp must have the same shape")
 
+    # Keep non-negative frequencies
     mask = f >= 0
-    f = np.abs(f[mask])
+    f = f[mask]
     a = a[mask]
 
     s = float(a.sum())
     if a.size == 0 or s <= 0.0:
-        return {
+        out: dict[str, float] = {
             "dominant_freq": 0.0,
             "spectral_centroid": 0.0,
             "spectral_bandwidth": 0.0,
             "peak_amplitude": 0.0,
+            "low_high_ratio": 0.0,
         }
+        for k in range(_TOPK):
+            out[f"peak_i_{k}"] = -1.0
+            out[f"peak_mag_{k}"] = 0.0
+        return out
 
     peak_idx = int(np.argmax(a))
     dominant = float(f[peak_idx])
@@ -31,12 +40,35 @@ def spectral_features(freq: Any, amp: Any) -> dict[str, float]:
     centroid = float((f * a).sum() / s)
     bandwidth = float(np.sqrt(((f - centroid) ** 2 * a).sum() / s))
 
-    return {
+    # Low/high energy ratio split by index (stable and fast)
+    mid = int(a.size // 2)
+    low = float(a[:mid].sum()) if mid > 0 else 0.0
+    high = float(a[mid:].sum())
+    low_high_ratio = float(low / (high + _EPS))
+
+    # Top-k peaks by amplitude: store bin index + normalized magnitude
+    k = min(_TOPK, int(a.size))
+    idx = np.argpartition(a, -k)[-k:]
+    idx = idx[np.argsort(a[idx])[::-1]]
+
+    amax = float(a.max())
+    out = {
         "dominant_freq": dominant,
         "spectral_centroid": centroid,
         "spectral_bandwidth": bandwidth,
-        "peak_amplitude": float(a.max()),
+        "peak_amplitude": amax,
+        "low_high_ratio": low_high_ratio,
     }
+    for j in range(_TOPK):
+        if j < idx.size:
+            i = int(idx[j])
+            out[f"peak_i_{j}"] = float(i)
+            out[f"peak_mag_{j}"] = float(a[i] / (amax + _EPS))
+        else:
+            out[f"peak_i_{j}"] = -1.0
+            out[f"peak_mag_{j}"] = 0.0
+
+    return out
 
 
 def timeseries_features(values: Any) -> dict[str, float]:


### PR DESCRIPTION
Extend eval spectral features: add low_high_ratio and top-5 peak bins/magnitudes.
Improve baseline by standardizing features (z-score) and reporting macro_f1.
Add dataset schema support (schema_version) and stream JSONL writing for scalability.
Preserve reproducibility fields (dt_requested/dt_used) in dataset params.

Validation
pre-commit run --all-files
ruff check .
black --check .
mypy tetrakis_sim
pytest -q