### PR TITLE
Evals hardening: stratified split + JSON metrics output

### DIFF
--- a/tests/test_evals_cli.py
+++ b/tests/test_evals_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from tetrakis_sim.evals.cli import main as eval_main
 
 
-def test_evals_cli_smoke(tmp_path: Path) -> None:
+def test_evals_cli_smoke(tmp_path: Path, capsys) -> None:
     out = tmp_path / "dc.jsonl"
 
     rc = eval_main(
@@ -41,5 +41,23 @@ def test_evals_cli_smoke(tmp_path: Path) -> None:
     assert "dt_requested" in rec0["params"]
     assert "dt_used" in rec0["params"]
 
-    rc2 = eval_main(["baseline", "--data", str(out), "--seed", "1", "--test-frac", "0.5"])
+    _ = capsys.readouterr()  # clear generate output
+
+    rc2 = eval_main(
+        [
+            "baseline",
+            "--data",
+            str(out),
+            "--seed",
+            "1",
+            "--test-frac",
+            "0.5",
+            "--split",
+            "stratified",
+        ]
+    )
     assert rc2 == 0
+
+    captured = capsys.readouterr().out
+    assert "accuracy" in captured
+    assert "macro_f1" in captured

--- a/tests/test_evals_smoke.py
+++ b/tests/test_evals_smoke.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from tetrakis_sim.evals.baseline import run_nearest_centroid_baseline
@@ -18,5 +20,6 @@ def test_evals_smoke(tmp_path: Path) -> None:
         dt=0.2,
         damping=0.0,
     )
-    metrics = run_nearest_centroid_baseline(out, seed=0, test_frac=0.5)
+    metrics = run_nearest_centroid_baseline(out, seed=0, test_frac=0.5, split="stratified")
     assert 0.0 <= metrics["accuracy"] <= 1.0
+    assert 0.0 <= metrics["macro_f1"] <= 1.0

--- a/tetrakis_sim/evals/cli.py
+++ b/tetrakis_sim/evals/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from .baseline import run_nearest_centroid_baseline
@@ -30,6 +31,8 @@ def build_parser() -> argparse.ArgumentParser:
     b.add_argument("--data", required=True, help="Input JSONL path")
     b.add_argument("--seed", type=int, default=0)
     b.add_argument("--test-frac", type=float, default=0.3)
+    b.add_argument("--split", choices=["random", "stratified"], default="stratified")
+    b.add_argument("--out-metrics", default=None, help="Optional path to write metrics as JSON")
 
     return parser
 
@@ -60,9 +63,20 @@ def main(argv: list[str] | None = None) -> int:
             args.data,
             seed=args.seed,
             test_frac=args.test_frac,
+            split=args.split,
         )
         for k in sorted(metrics):
             print(f"{k}: {metrics[k]}")
+
+        if args.out_metrics:
+            out = Path(args.out_metrics)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(
+                json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            print(f"wrote_metrics_json: {out}")
+
         return 0
 
     return 2


### PR DESCRIPTION
Summary
- Add stratified split option to eval baseline (default stratified for classification).
- Add optional JSON metrics output from `tetrakis-eval baseline`.
- Strengthen eval smoke tests to assert expected metric output.

Why
- Improves repeatability/robustness of eval harness (avoids missing-class splits when feasible).
- Produces machine-readable metrics for CI/regression tracking.

How to test
- pre-commit run --all-files
- pytest
- tetrakis-eval generate --out /tmp/dc.jsonl --n-per-class 10 --seed 0
- tetrakis-eval baseline --data /tmp/dc.jsonl --split stratified --out-metrics /tmp/metrics.json
