### PR TITLE
Docs: specify wave update + dt stability clamp

### DIFF
--- a/docs/model_and_validation.md
+++ b/docs/model_and_validation.md
@@ -4,6 +4,26 @@ This note documents (1) what the simulator is computing and (2) how to validate 
 
 ## Model summary
 
+### Parameters
+
+Common simulation parameters (stored in eval dataset records under `params`):
+
+- `size` (int): lattice width/height in base cells
+- `dim` (2|3): spatial dimension
+- `layers` (int): number of z-layers when `dim=3` (ignored when `dim=2`)
+- `steps` (int): number of update steps
+- `c` (float): wave speed parameter
+- `dt_requested` (float): timestep requested by the caller
+- `dt_used` (float): effective timestep used by the solver after stability clamping
+- `damping` (float): discrete damping factor
+
+Defect parameters (task-dependent):
+
+- `blackhole`: `center`, `radius`
+- `wedge`: `center` (and `layer` in 3D)
+- `singularity`: `center`, `radius`, `mass`, `potential`, `prune_edges`
+
+
 ### State space
 
 Tetrakis-Sim represents a discrete medium as a graph **G = (V, E)**:
@@ -22,14 +42,54 @@ Defects modify the graph (topology and/or node attributes):
 
 ### Dynamics (discrete wave update)
 
-Wave propagation is simulated as an explicit time-stepping update over the graph (Laplacian-driven coupling).
-Conceptually:
+Wave propagation is simulated as an explicit second-order time-stepping update over the graph.
 
-- `Δu(n) = Σ_{nb∈N(n)} u(nb) − deg(n)·u(n)`
-- the solver updates node values over time using `c` and `dt`, with optional damping
-- `mass` / `potential` node attributes (used by the singularity defect) modulate the local response
+#### Graph coupling term
 
-The implementation may clamp `dt` to avoid instability on dense graphs.
+For a node `n` with neighbor set `N(n)` and degree `deg(n)`, define:
+
+- `lap(n) = Σ_{nb∈N(n)} u_t(nb) − deg(n)·u_t(n)`
+
+(This is `A u − D u`, i.e. the negative of the unnormalized graph Laplacian `L = D − A`.)
+
+#### Update rule (as implemented)
+
+Let `u_t(n)` be the current state and `u_{t-1}(n)` the previous state. The solver uses an effective timestep `dt_eff` (possibly clamped) and:
+
+- `coeff = (c * dt_eff) ** 2`
+
+The update performed at each node is:
+
+- `u_{t+1}(n) = 2*u_t(n) - u_{t-1}(n) + (coeff * inv_mass(n))*lap(n) - (coeff * potential(n))*u_t(n) - damping*(u_t(n) - u_{t-1}(n))`
+
+Where:
+- `inv_mass(n) = 1/mass(n)` with any `mass <= 0` treated as `1.0`
+- `potential(n)` defaults to `0.0`
+
+These attributes are primarily used by the `singularity` defect.
+
+#### Stability heuristic (CFL-like dt clamp)
+
+The solver computes:
+
+- `max_degree = max_n deg(n)`
+- `stability_limit = 1 / sqrt(max_degree)` (only when `max_degree > 0` and `c > 0`)
+
+If `c * dt_requested > stability_limit`, it clamps:
+
+- `dt_eff = stability_limit / c`
+
+A `RuntimeWarning` is emitted when clamping occurs.
+
+It records:
+- `history.dt == dt_eff`
+- `history.metadata["stability_adjusted"]` (bool)
+- `history.metadata["stability_limit"]`
+- `history.metadata["effective_dt"]`
+
+The eval dataset generator stores both:
+- `params["dt_requested"]` (requested)
+- `params["dt_used"]` (effective)
 
 ## Observable outputs
 
@@ -74,7 +134,7 @@ tetrakis-eval generate --out /tmp/defect_classification.jsonl --n-per-class 20 -
 Score it with the baseline:
 
 ```bash
-tetrakis-eval baseline --data /tmp/defect_classification.jsonl --test-frac 0.3 --seed 0
+tetrakis-eval baseline --data /tmp/defect_classification.jsonl --test-frac 0.3 --seed 0 --split stratified
 ```
 
 This validates the full pipeline:
@@ -87,5 +147,5 @@ Notes:
 
 What to improve next:
 
-- Add one “golden” configuration in tests (fixed seed) whose key metrics are asserted (counts + a small set of features).
+- Add more “golden” configurations and assert a small, stable subset of numeric features (in addition to structural counts).
 - Expand the eval task set beyond defect classification (e.g., radius regression; layer classification for 3D).


### PR DESCRIPTION
Summary
- Add a Parameters section to docs/model_and_validation.md.
- Replace the Dynamics section with the exact wave update rule and the CFL-like dt clamp used by run_wave_sim.
- Update the eval harness sanity check command to use stratified splitting.

Why
- Removes ambiguity: documentation now matches implementation.
- Complements the existing “golden invariant” tests (defects + dt clamp behavior).

How to test
- pre-commit run --all-files
- pytest
