### PR TITLE
Refactor: add registry scaffold + extensibility doc

### DIFF
--- a/docs/architecture_extensibility.md
+++ b/docs/architecture_extensibility.md
@@ -1,0 +1,44 @@
+# Extensibility Architecture (Registry Scaffold)
+
+## Goal
+
+Allow new lattices, defects, and evaluation tasks to be added without editing multiple CLI modules or large `if/elif` blocks.
+
+## Registry concept
+
+`tetrakis_sim/registry.py` provides three registries:
+
+- `lattice`: graph builders (e.g., tetrakis 2D/3D sheet builders)
+- `defect`: defect operators (e.g., wedge, blackhole, singularity)
+- `eval_task`: dataset generation tasks (e.g., defect classification, radius regression)
+
+Each registry maps a stable string key (name) to a callable (`fn`) plus optional metadata (`description`).
+
+## Minimal API
+
+- `register(kind, name, fn, description=..., overwrite=False)`
+- `get(kind, name) -> fn`
+- `list_names(kind) -> [name, ...]`
+- Convenience wrappers:
+  - `register_lattice(name, fn, ...)`
+  - `register_defect(name, fn, ...)`
+  - `register_eval_task(name, fn, ...)`
+
+## Intended integration points
+
+In future refactors:
+
+- CLIs should map command-line choices to registry keys.
+- Example:
+  - `--defect wedge` selects `registry.get("defect", "wedge")`
+  - `--task defect_classification` selects `registry.get("eval_task", "defect_classification")`
+
+This keeps the CLI stable while allowing the implementation set to grow.
+
+## Next refactor step (optional)
+
+- Register the existing built-in implementations at import time:
+  - lattices: `build_sheet`
+  - defects: `apply_defect`
+  - eval tasks: `generate_defect_classification_jsonl`
+- Update `tetrakis-batch` and `tetrakis-eval` to use `list_names(...)` for argparse `choices=...`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,5 +7,6 @@
 deep_dive
 model_and_validation
 performance
+architecture_extensibility
 code_review
 PROJECT_REVIEW

--- a/tests/test_registry_scaffold.py
+++ b/tests/test_registry_scaffold.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from tetrakis_sim.registry import get, list_names, register_defect, register_lattice
+
+
+def test_registry_register_and_get() -> None:
+    def lattice_fn(size: int = 3) -> nx.Graph:
+        return nx.path_graph(size)
+
+    def defect_fn(G: nx.Graph, **kwargs):
+        return G, []
+
+    register_lattice("test_lattice", lattice_fn, description="test lattice", overwrite=True)
+    register_defect("test_defect", defect_fn, description="test defect", overwrite=True)
+
+    fnL = get("lattice", "test_lattice")
+    fnD = get("defect", "test_defect")
+
+    G = fnL(4)
+    assert isinstance(G, nx.Graph)
+    assert G.number_of_nodes() == 4
+
+    G2, removed = fnD(G)
+    assert G2.number_of_nodes() == 4
+    assert removed == []
+
+
+def test_registry_missing_raises() -> None:
+    with pytest.raises(KeyError):
+        _ = get("lattice", "does_not_exist")
+
+
+def test_list_names_includes_registered() -> None:
+    # Use overwrite=True to avoid conflicts across test runs.
+    register_lattice("test_list", lambda size=2: nx.path_graph(size), overwrite=True)
+    assert "test_list" in list_names("lattice")

--- a/tetrakis_sim/registry.py
+++ b/tetrakis_sim/registry.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal, TypeVar
+
+import networkx as nx
+
+T = TypeVar("T")
+
+Kind = Literal["lattice", "defect", "eval_task"]
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    name: str
+    kind: Kind
+    fn: Callable[..., Any]
+    description: str = ""
+
+
+_LATTICES: dict[str, RegistryEntry] = {}
+_DEFECTS: dict[str, RegistryEntry] = {}
+_EVAL_TASKS: dict[str, RegistryEntry] = {}
+
+
+def _bucket(kind: Kind) -> dict[str, RegistryEntry]:
+    if kind == "lattice":
+        return _LATTICES
+    if kind == "defect":
+        return _DEFECTS
+    if kind == "eval_task":
+        return _EVAL_TASKS
+    raise ValueError(f"Unknown kind: {kind}")
+
+
+def register(
+    kind: Kind,
+    name: str,
+    fn: Callable[..., Any],
+    *,
+    description: str = "",
+    overwrite: bool = False,
+) -> None:
+    """Register a callable under a kind/name.
+
+    Parameters
+    ----------
+    kind:
+        "lattice" | "defect" | "eval_task"
+    name:
+        Stable key used by CLIs/configs.
+    fn:
+        Callable implementing the behavior.
+    description:
+        Optional human-readable text for docs/help.
+    overwrite:
+        If False (default), re-registering an existing name raises.
+    """
+    if not name or not isinstance(name, str):
+        raise ValueError("name must be a non-empty string")
+
+    b = _bucket(kind)
+    if not overwrite and name in b:
+        raise KeyError(f"{kind} already registered: {name}")
+
+    b[name] = RegistryEntry(name=name, kind=kind, fn=fn, description=description)
+
+
+def get(kind: Kind, name: str) -> Callable[..., Any]:
+    """Retrieve a previously registered callable."""
+    b = _bucket(kind)
+    if name not in b:
+        raise KeyError(f"{kind} not registered: {name}")
+    return b[name].fn
+
+
+def describe(kind: Kind, name: str) -> RegistryEntry:
+    """Return the metadata for a registered entry."""
+    b = _bucket(kind)
+    if name not in b:
+        raise KeyError(f"{kind} not registered: {name}")
+    return b[name]
+
+
+def list_names(kind: Kind) -> list[str]:
+    """List registered names for a kind."""
+    return sorted(_bucket(kind).keys())
+
+
+# Convenience helpers (typed wrappers) ---------------------------------
+
+
+def register_lattice(
+    name: str,
+    fn: Callable[..., nx.Graph],
+    *,
+    description: str = "",
+    overwrite: bool = False,
+) -> None:
+    register("lattice", name, fn, description=description, overwrite=overwrite)
+
+
+def register_defect(
+    name: str,
+    fn: Callable[..., Any],
+    *,
+    description: str = "",
+    overwrite: bool = False,
+) -> None:
+    register("defect", name, fn, description=description, overwrite=overwrite)
+
+
+def register_eval_task(
+    name: str,
+    fn: Callable[..., Any],
+    *,
+    description: str = "",
+    overwrite: bool = False,
+) -> None:
+    register("eval_task", name, fn, description=description, overwrite=overwrite)


### PR DESCRIPTION
Summary
- Add tetrakis_sim/registry.py: a minimal registry for lattices, defects, and eval tasks.
- Add docs/architecture_extensibility.md describing intended integration.
- Add unit tests for the registry scaffold.

Why
- Provides a clean extension mechanism without scattering CLI conditionals.
- Sets up future refactors to make adding new models/tasks straightforward.

How to test
- pre-commit run --all-files
- pytest
